### PR TITLE
Added maximum upload rate to connection.

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,8 @@ const (
 	defaultDbType         = "memdb"
 	defaultPort           = "8444"
 	defaultRPCPort        = "8442"
+	defaultMaxUpPerPeer   = 2
+	defaultMaxDownPerPeer = 2
 )
 
 var (
@@ -88,6 +90,8 @@ type config struct {
 	CPUProfile     string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
 	DebugLevel     string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	Upnp           bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
+	MaxUpPerPeer   float64       `long:"maxuploadperpeer" description: "Maximum upload rate for any peer."`
+	MaxDownPerPeer float64       `lost:"maxdownloadperpeer" description: "Maximum download rate for any peer."`
 	onionlookup    func(string) ([]net.IP, error)
 	lookup         func(string) ([]net.IP, error)
 	oniondial      func(string, string) (net.Conn, error)
@@ -267,16 +271,18 @@ func newConfigParser(cfg *config, options flags.Options) *flags.Parser {
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		ConfigFile:    defaultConfigFile,
-		DebugLevel:    defaultLogLevel,
-		MaxPeers:      defaultMaxPeers,
-		BanDuration:   defaultBanDuration,
-		RPCMaxClients: defaultMaxRPCClients,
-		DataDir:       defaultDataDir,
-		LogDir:        defaultLogDir,
-		DbType:        defaultDbType,
-		RPCKey:        defaultRPCKeyFile,
-		RPCCert:       defaultRPCCertFile,
+		ConfigFile:     defaultConfigFile,
+		DebugLevel:     defaultLogLevel,
+		MaxPeers:       defaultMaxPeers,
+		BanDuration:    defaultBanDuration,
+		RPCMaxClients:  defaultMaxRPCClients,
+		DataDir:        defaultDataDir,
+		LogDir:         defaultLogDir,
+		DbType:         defaultDbType,
+		RPCKey:         defaultRPCKeyFile,
+		RPCCert:        defaultRPCCertFile,
+		MaxDownPerPeer: defaultMaxDownPerPeer,
+		MaxUpPerPeer:   defaultMaxUpPerPeer,
 	}
 
 	// Pre-parse the command line options to see if an alternative config

--- a/peer.go
+++ b/peer.go
@@ -514,7 +514,7 @@ func newOutboundPeer(addr string, s *server, stream uint32, persistent bool, ret
 	}
 
 	tcpAddr := &net.TCPAddr{IP: net.ParseIP(host), Port: int(port)}
-	conn := NewConn(tcpAddr, cfg.MaxDownPerPeer, cfg.MaxUpPerPeer)
+	conn := NewConn(tcpAddr, int64(cfg.MaxDownPerPeer), int64(cfg.MaxUpPerPeer))
 	inventory := peer.NewInventory()
 	sq := peer.NewSend(inventory, s.db)
 	logic := newPeerBase(tcpAddr, s, inventory, sq, false, persistent, retryCount)

--- a/peer.go
+++ b/peer.go
@@ -514,7 +514,7 @@ func newOutboundPeer(addr string, s *server, stream uint32, persistent bool, ret
 	}
 
 	tcpAddr := &net.TCPAddr{IP: net.ParseIP(host), Port: int(port)}
-	conn := NewConn(tcpAddr)
+	conn := NewConn(tcpAddr, cfg.MaxDownPerPeer, cfg.MaxUpPerPeer)
 	inventory := peer.NewInventory()
 	sq := peer.NewSend(inventory, s.db)
 	logic := newPeerBase(tcpAddr, s, inventory, sq, false, persistent, retryCount)

--- a/peer/connection_test.go
+++ b/peer/connection_test.go
@@ -171,6 +171,11 @@ func dialNewMockConn(localAddr net.Addr, fail bool, closed bool) func(service, a
 	}
 }
 
+const (
+	maxUpload   = 10000000
+	maxDownload = 10000000
+)
+
 func TestDial(t *testing.T) {
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
 	localAddr := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
@@ -178,7 +183,7 @@ func TestDial(t *testing.T) {
 	d := peer.TstSwapDial(dialNewMockConn(localAddr, false, false))
 	defer peer.TstSwapDial(d)
 
-	conn := peer.NewConnection(remoteAddr)
+	conn := peer.NewConnection(remoteAddr, maxUpload, maxDownload)
 	if conn == nil {
 		t.Errorf("No connection returned.")
 	}
@@ -192,7 +197,7 @@ func TestDial(t *testing.T) {
 	}
 
 	peer.TstSwapDial(dialNewMockConn(localAddr, true, false))
-	conn = peer.NewConnection(remoteAddr)
+	conn = peer.NewConnection(remoteAddr, maxUpload, maxDownload)
 	err = conn.Connect()
 	if err == nil {
 		t.Errorf("Error expected dialing failed connection.")
@@ -208,7 +213,7 @@ func TestUnconnectedConnection(t *testing.T) {
 	d := peer.TstSwapDial(dialNewMockConn(localAddr, false, false))
 	defer peer.TstSwapDial(d)
 
-	conn := peer.NewConnection(remoteAddr)
+	conn := peer.NewConnection(remoteAddr, maxUpload, maxDownload)
 	if conn.RemoteAddr() != nil {
 		t.Error("There should be no remote addr before connecting.")
 	}
@@ -231,14 +236,14 @@ func TestInterruptedConnection(t *testing.T) {
 	d := peer.TstSwapDial(dialNewMockConn(localAddr, false, true))
 	defer peer.TstSwapDial(d)
 
-	conn := peer.NewConnection(remoteAddr)
+	conn := peer.NewConnection(remoteAddr, maxUpload, maxDownload)
 	conn.Connect()
 	msg, err := conn.ReadMessage()
 	if err == nil || msg != nil {
 		t.Error("Connection should be closed.")
 	}
 
-	conn = peer.NewConnection(remoteAddr)
+	conn = peer.NewConnection(remoteAddr, maxUpload, maxDownload)
 	conn.Connect()
 	err = conn.WriteMessage(&wire.MsgVerAck{})
 	if err == nil {

--- a/peer/listener.go
+++ b/peer/listener.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/DanielKrawisz/maxrate"
 	"github.com/monetas/bmutil/wire"
 )
 
@@ -24,6 +25,8 @@ type Listener interface {
 // and creates new bitmessage connections as new peers dial in.
 type listener struct {
 	netListener net.Listener
+	maxDown     int64
+	maxUp       int64
 }
 
 // Accept blocks until a new connection dials in. It returns a Connection object,
@@ -38,6 +41,8 @@ func (pl *listener) Accept() (Connection, error) {
 		conn:        conn,
 		addr:        conn.RemoteAddr(),
 		idleTimeout: time.Minute * pingTimeoutMinutes,
+		maxDown:     maxrate.New(float64(pl.maxDown), 1),
+		maxUp:       maxrate.New(float64(pl.maxUp), 1),
 	}
 
 	connection.idleTimer = time.AfterFunc(connection.idleTimeout, func() {

--- a/peer_test.go
+++ b/peer_test.go
@@ -876,8 +876,8 @@ func TestOutboundPeerHandshake(t *testing.T) {
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
 
 	// A peer that establishes a handshake for outgoing peers.
-	handshakePeerBuilder := func(action *PeerAction) func(net.Addr, float64, float64) peer.Connection {
-		return func(addr net.Addr, maxDown, maxUp float64) peer.Connection {
+	handshakePeerBuilder := func(action *PeerAction) func(net.Addr, int64, int64) peer.Connection {
+		return func(addr net.Addr, maxDown, maxUp int64) peer.Connection {
 			return NewMockConnection(localAddr, remoteAddr, report,
 				NewOutboundHandshakePeerTester(action, msgAddr))
 		}

--- a/peer_test.go
+++ b/peer_test.go
@@ -876,8 +876,8 @@ func TestOutboundPeerHandshake(t *testing.T) {
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
 
 	// A peer that establishes a handshake for outgoing peers.
-	handshakePeerBuilder := func(action *PeerAction) func(net.Addr) peer.Connection {
-		return func(addr net.Addr) peer.Connection {
+	handshakePeerBuilder := func(action *PeerAction) func(net.Addr, float64, float64) peer.Connection {
+		return func(addr net.Addr, maxDown, maxUp float64) peer.Connection {
 			return NewMockConnection(localAddr, remoteAddr, report,
 				NewOutboundHandshakePeerTester(action, msgAddr))
 		}


### PR DESCRIPTION
The connection now enforces a maximum upload and download rate of 2mb per minute. Kind of small, but we can adjust it upward once bmd is a better citizen overall. 

I made options in config for MaxUpRatePerPeer and MaxDownRatePeerPeer but I don't think I did this correctly. Please check on what I did in config.go and tell me how to correct it. 