### PR TITLE
RPC Server and Fixes in database

### DIFF
--- a/README_RPC.md
+++ b/README_RPC.md
@@ -1,0 +1,89 @@
+# JSON-RPC over WebSockets
+
+The RPC server listens for JSON-RPC requests over a WebSockets connection at '/'.
+This is because the connection is supposed to be bidirectional, to make it
+possible for the server to push data to connected clients.
+
+## Points to Note
+- All binary data is base64 encoded.
+- Unauthenticated client connection is closed after `rpcAuthTimeoutSeconds`
+seconds.
+
+
+## RPC Client API
+
+Connected clients are expected to implement the following API. This ensures that
+the server can push data to where it's needed. If the server is unable to call
+a remote method, the connection is immediately terminated.
+
+```go
+func ReceiveMessage(object []byte, counter uint64)
+```
+```go
+func ReceiveBroadcast(object []byte, counter uint64)
+```
+```go
+func ReceiveGetpubkey(object []byte, counter uint64)
+```
+```go
+func ReceivePubkey(object []byte, counter uint64)
+```
+```go
+func ReceiveUnknownObject(object []byte, counter uint64)
+```
+Receive objects of the given type from the server. Order of receiving objects
+(especially the initial unsynchronized ones) may be random. Client
+implementations must not rely on sequential values of counter. However, values
+of counter are guaranteed to be unique.
+
+## RPC Calls
+-----------
+
+```go
+func Authenticate(username string, password string) bool
+```
+Authenticate the current connection with the specified credentials. The boolean
+return value tells whether the attempt succeeded or failed.
+
+```go
+func SendObject(object []byte) uint64
+```
+Send the specified object onto the network. object is a byte slice containing
+a serialized object (just the payload part of an object message). The object is
+first verified, then inserted into bmd's database and advertised onto the
+network. Return value is the counter value of the inserted object.
+
+```go
+type Identity struct { // basically a dictionary
+	address             string
+	nonceTrialsPerByte  uint64
+	extraBytes          uint64
+	signingKey          []byte
+	encryptionKey       []byte
+}
+
+func GetIdentity(address string) Identity
+```
+Retrieve the public identity of the given address. This is constructed from
+public keys stored in the database. If the public key for the specified address
+doesn't exist, an error is returned.
+
+```go
+func SubscribeMessages(fromCounter uint64)
+```
+```go
+func SubscribeBroadcasts(fromCounter uint64)
+```
+```go
+func SubscribeGetpubkeys(fromCounter uint64)
+```
+```go
+func SubscribePubkeys(fromCounter uint64)
+```
+```go
+func SubscribeUnknownObjects(fromCounter uint64)
+```
+
+Subscribe the client to the given object messages that have counter values
+starting from `fromCounter`. These objects are pushed to the client side using
+RPC Client API (refer above).

--- a/database/db.go
+++ b/database/db.go
@@ -43,18 +43,18 @@ type Db interface {
 
 	// FetchObjectByCounter returns the corresponding object based on the
 	// counter. Note that each object type has a different counter, with unknown
-	// object having none. Currently, the only objects to have counters are
-	// messages and broadcasts because they make little sense for anything else.
-	// Counters are meant for used as a convenience method for fetching new data
-	// from database since last check.
+	// objects being consolidated into one counter. Counters are meant for use
+	// as a convenience method for fetching new data from database since last
+	// check.
 	FetchObjectByCounter(wire.ObjectType, uint64) ([]byte, error)
 
-	// FetchObjectsFromCounter returns `count' objects which have a counter
-	// position starting from `counter'. It also returns the counter value of
-	// the last object. Objects are guaranteed to be returned in order of
-	// increasing counter.
+	// FetchObjectsFromCounter returns a map of `count' objects which have a
+	// counter position starting from `counter'. Key is the value of counter and
+	// value is a byte slice containing the object. It also returns the counter
+	// value of the last object, which could be useful for more queries to the
+	// function.
 	FetchObjectsFromCounter(objType wire.ObjectType, counter uint64,
-		count uint64) ([][]byte, uint64, error)
+		count uint64) (map[uint64][]byte, uint64, error)
 
 	// FetchIdentityByAddress returns identity.Public stored in the form
 	// of a PubKey message in the pubkey database.

--- a/peer/send_test.go
+++ b/peer/send_test.go
@@ -199,7 +199,7 @@ func (db *MockDb) FetchObjectByCounter(wire.ObjectType, uint64) ([]byte, error) 
 }
 
 func (db *MockDb) FetchObjectsFromCounter(objType wire.ObjectType, counter uint64,
-	count uint64) ([][]byte, uint64, error) {
+	count uint64) (map[uint64][]byte, uint64, error) {
 	return nil, 0, nil
 }
 

--- a/rpcmethods.go
+++ b/rpcmethods.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2015 Monetas.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cenkalti/rpc2"
+	"github.com/monetas/bmd/database"
+	"github.com/monetas/bmutil"
+	"github.com/monetas/bmutil/pow"
+	"github.com/monetas/bmutil/wire"
+)
+
+// RPCAuthArgs contains arguments for Authenticate.
+type RPCAuthArgs struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// handleAuth authenticates a websocket client using the supplied username and
+// password. If the supplied authentication does not match the username and
+// password expected, an error is returned.
+//
+// This check is time-constant.
+//
+// The function sets the values of isAuthenticated and isAdmin for the client.
+// The first bool return value signifies auth success (true if successful) and
+// the second bool return value specifies whether the user can change the state
+// of the server (true) or whether the user is limited (false). The second is
+// always false if the first is.
+func (s *rpcServer) handleAuth(client *rpc2.Client, in *RPCAuthArgs, success *bool) error {
+	login := in.Username + ":" + in.Password
+	authsha := sha256.Sum256([]byte(login))
+	c := client.State
+
+	// Check for limited auth first as in environments with limited users, those
+	// are probably expected to have a higher volume of calls
+	limitcmp := subtle.ConstantTimeCompare(authsha[:], s.limitauthsha[:])
+	if limitcmp == 1 {
+		c.Set(rpcStateIsAuthenticated, true)
+		c.Set(rpcStateIsAdmin, false)
+		*success = true
+		return nil
+	}
+
+	// Check for admin-level auth
+	cmp := subtle.ConstantTimeCompare(authsha[:], s.authsha[:])
+	if cmp == 1 {
+		c.Set(rpcStateIsAuthenticated, true)
+		c.Set(rpcStateIsAdmin, true)
+		*success = true
+		return nil
+	}
+
+	*success = false
+	state := rpcConstructState(client)
+	rpcLog.Warnf("RPC authentication failure from %s.", state.remoteAddr)
+
+	return nil
+}
+
+// objectsSend sends the requested object into the Bitmessage network. in is
+// a base64 representation of the object.
+func (s *rpcServer) sendObject(client *rpc2.Client, in string, counter *uint64) error {
+	if err := s.restrictAuth(client); err != nil {
+		return err
+	}
+	data, err := base64.StdEncoding.DecodeString(in)
+	if err != nil {
+		return errors.New("base64 decode failed")
+	}
+
+	// Check whether the object is valid.
+	_, expiresTime, _, _, stream, err := wire.DecodeMsgObjectHeader(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("invalid object: %v", err)
+	}
+	if time.Now().After(expiresTime) { // already expired
+		return errors.New("object already expired")
+	}
+	if stream != 1 { // TODO improve
+		return errors.New("invalid stream")
+	}
+
+	// Check whether the PoW is valid.
+	if !pow.Check(data, pow.DefaultExtraBytes, pow.DefaultNonceTrialsPerByte,
+		time.Now()) {
+		return errors.New("invalid proof of work")
+	}
+
+	// Relay object to object manager which will handle insertion and
+	// advertisement.
+	hash, _ := wire.NewShaHash(bmutil.CalcInventoryHash(data))
+	*counter = s.server.objectManager.handleInsert(data, wire.NewInvVect(hash))
+	if *counter == 0 {
+		return errors.New("failed to insert and advertise object")
+	}
+	return nil
+}
+
+// RPCGetIDOut contains the output of GetIdentity.
+type RPCGetIDOut struct {
+	Address            string `json:"address"`
+	NonceTrialsPerByte uint64 `json:"nonceTrialsPerByte"`
+	ExtraBytes         uint64 `json:"extraBytes"`
+	// base64 encoded bytes
+	SigningKey    string `json:"signingKey"`
+	EncryptionKey string `json:"encryptionKey"`
+}
+
+// handleGetId returns the stored public key associated with the given
+// Bitmessage address.
+func (s *rpcServer) getID(client *rpc2.Client, addr string, id *RPCGetIDOut) error {
+	if err := s.restrictAuth(client); err != nil {
+		return err
+	}
+
+	address, err := bmutil.DecodeAddress(addr)
+	if err != nil {
+		return fmt.Errorf("address decode failed: %v", err)
+	}
+
+	pubID, err := s.server.db.FetchIdentityByAddress(address)
+	if err == database.ErrNonexistentObject {
+		return errors.New("identity not found")
+	} else if err != nil {
+		rpcLog.Errorf("FetchIdentityByAddress, database error: %v", err)
+		return errors.New("database error")
+	}
+	id.Address = addr
+	id.NonceTrialsPerByte = pubID.NonceTrialsPerByte
+	id.ExtraBytes = pubID.ExtraBytes
+	id.EncryptionKey = base64.StdEncoding.EncodeToString(
+		pubID.EncryptionKey.SerializeUncompressed())
+	id.SigningKey = base64.StdEncoding.EncodeToString(
+		pubID.SigningKey.SerializeUncompressed())
+	return nil
+}
+
+// RPCSubscribeArgs contains the input for Subscribe methods.
+type RPCSubscribeArgs struct {
+	FromCounter uint64 `json:"fromCounter"`
+}
+
+// RPCReceiveArgs contains the input for Receive methods on the client side.
+type RPCReceiveArgs struct {
+	Object  string `json:"object"`
+	Counter uint64 `json:"counter"`
+}
+
+// subscribeMessages subscribes the client to receiving objects of type message
+// as soon as they are received by bmd. On the client side, ReceiveMessage RPC
+// method is called.
+func (s *rpcServer) subscribeMessages(client *rpc2.Client, args *RPCSubscribeArgs,
+	_ *struct{}) error {
+	return s.handleSubscribe(client, wire.ObjectTypeMsg, args, rpcEvtNewMessage,
+		rpcClientHandleMessage)
+}
+
+// subscribeBroadcasts subscribes the client to receiving objects of type
+// broadcast as soon as they are received by bmd. On the client side,
+// ReceiveBroadcast RPC method is called.
+func (s *rpcServer) subscribeBroadcasts(client *rpc2.Client, args *RPCSubscribeArgs,
+	_ *struct{}) error {
+	return s.handleSubscribe(client, wire.ObjectTypeBroadcast, args,
+		rpcEvtNewBroadcast, rpcClientHandleBroadcast)
+}
+
+// subscribeGetpubkeys subscribes the client to receiving objects of type
+// getpubkey as soon as they are received by bmd. On the client side,
+// ReceiveGetpubkey RPC method is called.
+func (s *rpcServer) subscribeGetpubkeys(client *rpc2.Client, args *RPCSubscribeArgs,
+	_ *struct{}) error {
+	return s.handleSubscribe(client, wire.ObjectTypeGetPubKey, args,
+		rpcEvtNewGetpubkey, rpcClientHandleGetpubkey)
+}
+
+// subscribePubkeys subscribes the client to receiving objects of type
+// pubkey as soon as they are received by bmd. On the client side,
+// ReceivePubkey RPC method is called.
+func (s *rpcServer) subscribePubkeys(client *rpc2.Client, args *RPCSubscribeArgs,
+	_ *struct{}) error {
+	return s.handleSubscribe(client, wire.ObjectTypePubKey, args,
+		rpcEvtNewPubkey, rpcClientHandlePubkey)
+}
+
+// subscribeUnknownObjects subscribes the client to receiving objects of unknown
+// type as soon as they are received by bmd. On the client side,
+// ReceiveUnknownObject RPC method is called.
+func (s *rpcServer) subscribeUnknownObjects(client *rpc2.Client, args *RPCSubscribeArgs,
+	_ *struct{}) error {
+	// XXX just a hack
+	return s.handleSubscribe(client, wire.ObjectType(999999), args,
+		rpcEvtNewUnknownObj, rpcClientHandleUnknownObj)
+}
+
+func (s *rpcServer) handleSubscribe(client *rpc2.Client, objType wire.ObjectType,
+	args *RPCSubscribeArgs, evt string, clientHandler string) error {
+	// Make sure only authenticated users can subscribe to objects.
+	if err := s.restrictAuth(client); err != nil {
+		return err
+	}
+	state := rpcConstructState(client)
+
+	s.evtMgr.On(evt, func(out *RPCReceiveArgs) {
+		err := client.Call(clientHandler, out, nil)
+		if err != nil {
+			rpcLog.Infof("failed to call %s on client %s: %v", clientHandler,
+				state.remoteAddr, err)
+			client.Close()
+		}
+	}, state.eventsID)
+
+	// We subscribe to event before sending old objects because otherwise there
+	// might be misses because of race conditions. Duplication >> Misses.
+	return s.sendOldObjects(client, objType, args.FromCounter, clientHandler)
+}
+
+// sendOldObjects is used to send objects of a particular type starting from a
+// fixed counter value to the client.
+func (s *rpcServer) sendOldObjects(client *rpc2.Client, objType wire.ObjectType,
+	fromCounter uint64, clientHandler string) error {
+	objs, lastCount, err := s.server.db.FetchObjectsFromCounter(objType,
+		fromCounter, rpcCounterObjectsSize)
+	if err != nil {
+		rpcLog.Errorf("FetchObjectsFromCounter, database error: %v", err)
+		return errors.New("database error")
+	}
+	state := rpcConstructState(client)
+
+	wg := sync.WaitGroup{}
+	var callError uint64
+
+	for counter, msg := range objs {
+		out := &RPCReceiveArgs{
+			Object:  base64.StdEncoding.EncodeToString(msg),
+			Counter: counter,
+		}
+		// Send objects to client. Terminate all requests if one fails.
+		go func() {
+			wg.Add(1)
+			call := client.Go(clientHandler, out, nil, nil)
+		out:
+			for {
+				select {
+				case <-call.Done:
+					if call.Error != nil {
+						rpcLog.Infof("failed to call %s on client %s: %v",
+							clientHandler, state.remoteAddr, err)
+						// Can't use channels because of possible race
+						// conditions while trying to close them.
+						atomic.StoreUint64(&callError, 1)
+					}
+					break out
+				default:
+					if atomic.LoadUint64(&callError) == 1 {
+						break out
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()           // wait for all requests to finish
+	if callError == 1 { // there was an error
+		client.Close()
+	}
+
+	// We might have more objects to send.
+	if len(objs) == rpcCounterObjectsSize {
+		return s.sendOldObjects(client, objType, lastCount, clientHandler)
+	}
+	return nil
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1,0 +1,464 @@
+// Originally derived from: btcsuite/btcd/rpcserver.go
+// Copyright (c) 2013-2015 The btcsuite developers.
+
+// Copyright (c) 2015 Monetas.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	prand "math/rand"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
+	"github.com/gorilla/websocket"
+	"github.com/ishbir/eventemitter"
+	"github.com/monetas/bmutil/wire"
+)
+
+const (
+	// rpcAuthTimeoutSeconds is the number of seconds a connection to the
+	// RPC server is allowed to stay open without authenticating before it
+	// is closed.
+	rpcAuthTimeoutSeconds = 5
+
+	// rpcCounterObjectsSize is the number of objects that db.FetchObjectsFromCounter
+	// will fetch per query to the database. This is used when a client requests
+	// subscription to an object type from a specified counter value.
+	rpcCounterObjectsSize = 100
+)
+
+const (
+	// RPC server local new object event handlers.
+	rpcEvtNewMessage    = "newMessage"
+	rpcEvtNewBroadcast  = "newBroadcast"
+	rpcEvtNewGetpubkey  = "newGetpubkey"
+	rpcEvtNewPubkey     = "newPubkey"
+	rpcEvtNewUnknownObj = "newUnknownObject"
+
+	// Methods defined on RPC server
+	rpcHandleAuth        = "Authenticate"
+	rpcHandleSendObject  = "SendObject"
+	rpcHandleGetIdentity = "GetIdentity"
+
+	rpcSubscribePrefix            = "Subscribe"
+	rpcHandleSubscribeMessages    = rpcSubscribePrefix + "Messages"
+	rpcHandleSubscribeBroadcasts  = rpcSubscribePrefix + "Broadcasts"
+	rpcHandleSubscribeGetpubkeys  = rpcSubscribePrefix + "Getpubkeys"
+	rpcHandleSubscribePubkeys     = rpcSubscribePrefix + "Pubkeys"
+	rpcHandleSubscribeUnknownObjs = rpcSubscribePrefix + "UnknownObjects"
+
+	// Methods defined on RPC client
+	rpcClientObjectHandlePrefix = "Receive"
+	rpcClientHandleMessage      = rpcClientObjectHandlePrefix + "Message"
+	rpcClientHandleBroadcast    = rpcClientObjectHandlePrefix + "Broadcast"
+	rpcClientHandleGetpubkey    = rpcClientObjectHandlePrefix + "Getpubkey"
+	rpcClientHandlePubkey       = rpcClientObjectHandlePrefix + "Pubkey"
+	rpcClientHandleUnknownObj   = rpcClientObjectHandlePrefix + "UnknownObject"
+
+	// Various states contained in client.State
+	rpcStateRemoteAddr      = "remoteAddr"      // string
+	rpcStateIsAuthenticated = "isAuthenticated" // bool
+	rpcStateIsAdmin         = "isAdmin"         // bool
+	rpcStateEventsID        = "eventsID"        // int
+)
+
+var (
+	// upgrader upgrades a normal HTTP connection to websocket.
+	upgrader = websocket.Upgrader{
+		ReadBufferSize:  4096,
+		WriteBufferSize: 4096,
+	}
+
+	// errAccessDenied is the error sent to the client when it tries to connect
+	// to a RPC method without having authenticated.
+	errAccessDenied = errors.New("access denied")
+)
+
+// rpcClientParams holds items that are relevant to a connected client.
+type rpcClientState struct {
+	remoteAddr      string
+	isAuthenticated bool
+	isAdmin         bool
+	// a psuedorandom value used to associate client with subscribed events
+	eventsID int
+}
+
+// constructState constructs a rpcClientState object for a given client.
+func rpcConstructState(client *rpc2.Client) *rpcClientState {
+	state := new(rpcClientState)
+
+	r, _ := client.State.Get(rpcStateRemoteAddr)
+	state.remoteAddr = r.(string)
+
+	ev, _ := client.State.Get(rpcStateEventsID)
+	state.eventsID = ev.(int)
+
+	isAuth, _ := client.State.Get(rpcStateIsAuthenticated)
+	state.isAuthenticated = isAuth.(bool)
+
+	isAdmin, _ := client.State.Get(rpcStateIsAdmin)
+	state.isAdmin = isAdmin.(bool)
+
+	return state
+}
+
+// rpcServer holds the items the rpc server may need to access (config,
+// shutdown, main server, etc.)
+type rpcServer struct {
+	server       *server
+	rpcSrv       *rpc2.Server
+	listeners    []net.Listener
+	evtMgr       *eventemitter.EventEmitter
+	limitauthsha [sha256.Size]byte
+	authsha      [sha256.Size]byte
+	mutex        sync.RWMutex
+	clients      map[*rpc2.Client]struct{}
+	started      int32
+	shutdown     int32
+	wg           sync.WaitGroup
+	quit         chan int
+}
+
+// addHandlers is responsible for adding RPC method handlers to the underlying
+// RPC server. Moreover, it also adds event handlers to the event manager so
+// that events sent by bmd (like new broadcast/message/pubkey) or those from the
+// RPC server can be handled (e.g. notifying any interested clients).
+func (s *rpcServer) addHandlers() {
+	// When client connects/disconnects
+	s.rpcSrv.OnConnect(s.onClientConnect)
+	s.rpcSrv.OnDisconnect(s.onClientDisconnect)
+
+	// General
+	s.rpcSrv.Handle(rpcHandleAuth, s.handleAuth)
+
+	// Objects
+	s.rpcSrv.Handle(rpcHandleSendObject, s.sendObject)
+	s.rpcSrv.Handle(rpcHandleGetIdentity, s.getID)
+
+	// Statistics
+
+	// Notifications
+	s.rpcSrv.Handle(rpcHandleSubscribeMessages, s.subscribeMessages)
+	s.rpcSrv.Handle(rpcHandleSubscribeBroadcasts, s.subscribeBroadcasts)
+	s.rpcSrv.Handle(rpcHandleSubscribeGetpubkeys, s.subscribeGetpubkeys)
+	s.rpcSrv.Handle(rpcHandleSubscribePubkeys, s.subscribePubkeys)
+	s.rpcSrv.Handle(rpcHandleSubscribeUnknownObjs, s.subscribeUnknownObjects)
+
+}
+
+// onClientConnect is run for each client that connects to the RPC server.
+func (s *rpcServer) onClientConnect(client *rpc2.Client) {
+	s.mutex.Lock()
+	s.clients[client] = struct{}{}
+	s.mutex.Unlock()
+
+	// Enforce no authentication timeout.
+	go func() {
+		timer := time.NewTimer(time.Second * rpcAuthTimeoutSeconds)
+		<-timer.C
+
+		if isAuth, _ := client.State.Get(rpcStateIsAuthenticated); !isAuth.(bool) {
+			client.Close() // bad client
+		}
+	}()
+
+	state := rpcConstructState(client)
+	rpcLog.Infof("Client %s connected", state.remoteAddr)
+}
+
+// onClientDisconnect is run for each client that disconnects from the RPC server.
+func (s *rpcServer) onClientDisconnect(client *rpc2.Client) {
+	s.mutex.Lock()
+	delete(s.clients, client)
+	s.mutex.Unlock()
+
+	state := rpcConstructState(client)
+
+	// De-register all event handlers.
+	id := state.eventsID
+
+	s.evtMgr.RemoveListener(rpcEvtNewMessage, id)
+	s.evtMgr.RemoveListener(rpcEvtNewBroadcast, id)
+	s.evtMgr.RemoveListener(rpcEvtNewGetpubkey, id)
+	s.evtMgr.RemoveListener(rpcEvtNewPubkey, id)
+	s.evtMgr.RemoveListener(rpcEvtNewUnknownObj, id)
+
+	rpcLog.Infof("Client %s disconnected", state.remoteAddr)
+}
+
+// genCertPair generates a key/cert pair to the paths provided.
+func genCertPair(certFile, keyFile string) error {
+	rpcLog.Infof("Generating TLS certificates...")
+
+	org := "bmd autogenerated cert"
+	validUntil := time.Now().Add(10 * 365 * 24 * time.Hour)
+	cert, key, err := btcutil.NewTLSCertPair(org, validUntil, nil)
+	if err != nil {
+		return err
+	}
+
+	// Write cert and key files.
+	if err = ioutil.WriteFile(certFile, cert, 0666); err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
+		os.Remove(certFile)
+		return err
+	}
+
+	rpcLog.Infof("Done generating TLS certificates")
+	return nil
+}
+
+// limitConnections responds with a 503 service unavailable and returns true if
+// adding another client would exceed the maximum allowed RPC clients.
+//
+// This function is safe for concurrent access.
+func (s *rpcServer) limitConnections(w http.ResponseWriter, remoteAddr string) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if int(len(s.clients)+1) > cfg.RPCMaxClients {
+		rpcLog.Infof("Max RPC clients exceeded [%d] - disconnecting client %s",
+			cfg.RPCMaxClients, remoteAddr)
+		http.Error(w, "503 Too busy. Try again later.",
+			http.StatusServiceUnavailable)
+		return true
+	}
+	return false
+}
+
+// restrictAuth restricts access of the client, returning an error if the client
+// is not already authenticated.
+func (s *rpcServer) restrictAuth(client *rpc2.Client) error {
+	state := rpcConstructState(client)
+	if !state.isAuthenticated {
+		return errAccessDenied
+	}
+	return nil
+}
+
+// restrictAdmin restricts access of the client, returning an error if the
+// client is not already authenticated as an admin.
+func (s *rpcServer) restrictAdmin(client *rpc2.Client) error {
+	state := rpcConstructState(client)
+	if !state.isAdmin {
+		return errAccessDenied
+	}
+	return nil
+}
+
+// NotifyObject is used to notify the RPC server of any new objects so that it
+// can send those onwards to the client.
+func (s *rpcServer) NotifyObject(msg []byte, counter uint64) {
+	// Find type of object.
+	_, _, objType, _, _, err := wire.DecodeMsgObjectHeader(bytes.NewReader(msg))
+	if err != nil {
+		panic(fmt.Sprintf("invalid object: %v", err))
+	}
+	out := &RPCReceiveArgs{
+		Object:  base64.StdEncoding.EncodeToString(msg),
+		Counter: counter,
+	}
+
+	switch objType {
+	case wire.ObjectTypeBroadcast:
+		s.evtMgr.Emit(rpcEvtNewBroadcast, out)
+	case wire.ObjectTypeGetPubKey:
+		s.evtMgr.Emit(rpcEvtNewGetpubkey, out)
+	case wire.ObjectTypeMsg:
+		s.evtMgr.Emit(rpcEvtNewMessage, out)
+	case wire.ObjectTypePubKey:
+		s.evtMgr.Emit(rpcEvtNewPubkey, out)
+	default:
+		s.evtMgr.Emit(rpcEvtNewUnknownObj, out)
+	}
+}
+
+// newRPCServer returns a new instance of the rpcServer struct.
+func newRPCServer(listenAddrs []string, s *server) (*rpcServer, error) {
+	rpc := rpcServer{
+		server:  s,
+		rpcSrv:  rpc2.NewServer(),   // Create the underlying RPC server.
+		evtMgr:  eventemitter.New(), // Event manager.
+		quit:    make(chan int),
+		clients: make(map[*rpc2.Client]struct{}),
+	}
+
+	if cfg.RPCUser != "" && cfg.RPCPass != "" {
+		login := cfg.RPCUser + ":" + cfg.RPCPass
+		rpc.authsha = sha256.Sum256([]byte(login))
+	}
+	if cfg.RPCLimitUser != "" && cfg.RPCLimitPass != "" {
+		login := cfg.RPCLimitUser + ":" + cfg.RPCLimitPass
+		rpc.limitauthsha = sha256.Sum256([]byte(login))
+	}
+
+	// Setup TLS if not disabled.
+	listenFunc := net.Listen
+	if !cfg.DisableTLS {
+		// Generate the TLS cert and key file if both don't already
+		// exist.
+		if !fileExists(cfg.RPCKey) && !fileExists(cfg.RPCCert) {
+			err := genCertPair(cfg.RPCCert, cfg.RPCKey)
+			if err != nil {
+				return nil, err
+			}
+		}
+		keypair, err := tls.LoadX509KeyPair(cfg.RPCCert, cfg.RPCKey)
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig := tls.Config{
+			Certificates: []tls.Certificate{keypair},
+			MinVersion:   tls.VersionTLS12,
+		}
+
+		// Change the standard net.Listen function to the tls one.
+		listenFunc = func(net string, laddr string) (net.Listener, error) {
+			return tls.Listen(net, laddr, &tlsConfig)
+		}
+	}
+
+	// TODO(oga) this code is similar to that in server, should be
+	// factored into something shared.
+	ipv4ListenAddrs, ipv6ListenAddrs, _, err := parseListeners(listenAddrs)
+	if err != nil {
+		return nil, err
+	}
+	listeners := make([]net.Listener, 0,
+		len(ipv6ListenAddrs)+len(ipv4ListenAddrs))
+	for _, addr := range ipv4ListenAddrs {
+		listener, err := listenFunc("tcp4", addr)
+		if err != nil {
+			rpcLog.Warnf("Can't listen on %s: %v", addr, err)
+			continue
+		}
+		listeners = append(listeners, listener)
+	}
+
+	for _, addr := range ipv6ListenAddrs {
+		listener, err := listenFunc("tcp6", addr)
+		if err != nil {
+			rpcLog.Warnf("Can't listen on %s: %v", addr, err)
+			continue
+		}
+		listeners = append(listeners, listener)
+	}
+	if len(listeners) == 0 {
+		return nil, errors.New("RPC: No valid listen address")
+	}
+
+	rpc.listeners = listeners
+	rpc.addHandlers()
+
+	return &rpc, nil
+}
+
+// Stop is used by server.go to stop the rpc listener.
+func (s *rpcServer) Stop() error {
+	if atomic.AddInt32(&s.shutdown, 1) != 1 {
+		rpcLog.Infof("RPC server is already in the process of shutting down")
+		return nil
+	}
+	rpcLog.Warnf("RPC server shutting down")
+
+	for _, listener := range s.listeners {
+		err := listener.Close()
+		if err != nil {
+			rpcLog.Errorf("Problem shutting down rpc: %v", err)
+			return err
+		}
+	}
+
+	// These events are for the RPC server to forward objects received from
+	// bmd.server to the client. They are emitted by NotifyObject because
+	// bmd.server sends objects in the format most convenient to it (byte slice).
+	// This then needs to be converted into a format that's appropriate for
+	// transfer by RPC server to the clients, base64.
+	s.evtMgr.RemoveListeners(rpcEvtNewMessage)
+	s.evtMgr.RemoveListeners(rpcEvtNewBroadcast)
+	s.evtMgr.RemoveListeners(rpcEvtNewGetpubkey)
+	s.evtMgr.RemoveListeners(rpcEvtNewPubkey)
+	s.evtMgr.RemoveListeners(rpcEvtNewUnknownObj)
+
+	close(s.quit)
+	s.wg.Wait()
+	rpcLog.Infof("RPC server shutdown complete")
+	return nil
+}
+
+// Start is used by server.go to start the rpc listener.
+func (s *rpcServer) Start() {
+	if atomic.AddInt32(&s.started, 1) != 1 {
+		return
+	}
+
+	rpcLog.Trace("Starting RPC server")
+
+	// Create mux for handling requests. This is necessary because if profiling
+	// is enabled, then both profiler and RPC would be accessible from both
+	// servers.
+	rpcServeMux := http.NewServeMux()
+	httpServer := &http.Server{
+		Handler: rpcServeMux,
+	}
+
+	rpcServeMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Enforce cfg.RPCMaxClients
+		if s.limitConnections(w, r.RemoteAddr) {
+			return
+		}
+
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			if _, ok := err.(websocket.HandshakeError); !ok {
+				rpcLog.Errorf("Unexpected websocket error: %v", err)
+			}
+
+			http.Error(w, "400 Bad Request.", http.StatusBadRequest)
+			return
+		}
+		// Initialize state for client.
+		state := rpc2.NewState()
+		state.Set(rpcStateRemoteAddr, r.RemoteAddr)
+		state.Set(rpcStateEventsID, prand.Int())
+		state.Set(rpcStateIsAdmin, false)
+		state.Set(rpcStateIsAuthenticated, false)
+
+		s.rpcSrv.ServeCodecWithState(jsonrpc.NewJSONCodec(ws.UnderlyingConn()),
+			state)
+	})
+
+	// Start listening on the listeners.
+	for _, listener := range s.listeners {
+		s.wg.Add(1)
+		go func(listener net.Listener) {
+			rpcLog.Infof("RPC server listening on %s", listener.Addr())
+			httpServer.Serve(listener)
+			rpcLog.Tracef("RPC listener done for %s", listener.Addr())
+			s.wg.Done()
+		}(listener)
+	}
+}
+
+func init() {
+	prand.Seed(time.Now().UnixNano())
+}

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) 2015 Monetas.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
+	"github.com/gorilla/websocket"
+	"github.com/monetas/bmd/peer"
+	"github.com/monetas/bmutil"
+	"github.com/monetas/bmutil/wire"
+)
+
+const (
+	rpcLoc = "ws://localhost:8442/"
+
+	rpcAdminUser = "admin"
+	rpcAdminPass = "admin"
+
+	rpcLimitUser = "limit"
+	rpcLimitPass = "limit"
+)
+
+var serv *server
+
+var subscribeArgs = &RPCSubscribeArgs{
+	FromCounter: 0,
+}
+
+func rpcTests(client *rpc2.Client, t *testing.T) {
+	// Do not change test order. Tests depend on previous tests successfully
+	// finishing.
+	testRPCAuth(client, t)
+	testRPCSendObject(client, t)
+	testRPCSubscriptions(client, t)
+}
+
+// testRPCAuth tests authentication failures for all RPC methods and also
+// Authenticate method.
+func testRPCAuth(client *rpc2.Client, t *testing.T) {
+	// Test access denied.
+	failTests := []struct {
+		method string
+		args   interface{}
+	}{
+		{rpcHandleSendObject, "Y="},
+		{rpcHandleGetIdentity, "BM-asd5s"},
+		{rpcHandleSubscribeMessages, subscribeArgs},
+		{rpcHandleSubscribeBroadcasts, subscribeArgs},
+		{rpcHandleSubscribeGetpubkeys, subscribeArgs},
+		{rpcHandleSubscribePubkeys, subscribeArgs},
+		{rpcHandleSubscribeUnknownObjs, subscribeArgs},
+	}
+
+	for _, test := range failTests {
+		err := client.Call(test.method, test.args, nil)
+		if err.Error() != errAccessDenied.Error() { // auth failure
+			t.Errorf("for %s expected %v got %v", test.method, errAccessDenied,
+				err)
+		}
+	}
+
+	// Test Authenticate.
+	authTests := []struct {
+		username string
+		password string
+		success  bool
+	}{
+		{"", "", false},
+		{"sadsadadoijsad", "asdfsafafdfasdfdf", false},
+		{rpcLimitUser, rpcLimitPass, true},
+		{rpcAdminUser, rpcAdminPass, true},
+	}
+
+	for i, test := range authTests {
+		args := &RPCAuthArgs{
+			Username: test.username,
+			Password: test.password,
+		}
+		var res bool
+		err := client.Call(rpcHandleAuth, args, &res)
+
+		if err != nil {
+			t.Errorf("for case #%d got error %v", i, err)
+		}
+		if test.success != res {
+			t.Errorf("for case #%d expected %v got %v", i, test.success, res)
+		}
+	}
+}
+
+// Test SendObject.
+func testRPCSendObject(client *rpc2.Client, t *testing.T) {
+
+	// invalid base64 encoding
+	err := client.Call(rpcHandleSendObject, "aodisad093predikif", nil)
+	if err == nil {
+		t.Error("got no error for invalid base64 encoding")
+	}
+
+	errorTests := [][]byte{
+		[]byte{},                       // empty
+		[]byte{0x00, 0x00, 0x00, 0x00}, // invalid object
+		[]byte{ // expired
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xe0, 0xf3, // Nonce
+			0x00, 0x00, 0x00, 0x00, 0x49, 0x5f, 0xab, 0x29, // 64-bit Timestamp
+			0x00, 0x00, 0x00, 0x00, // object type
+			0x03, // Version
+			0x01, // Stream Number
+		},
+		[]byte{ // invalid stream
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xe0, 0xf3, // Nonce
+			0x00, 0x00, 0x00, 0xff, 0x49, 0x5f, 0xab, 0x29, // 64-bit Timestamp
+			0x00, 0x00, 0x00, 0x00, // object type
+			0x03, // Version
+			0x05, // Stream Number
+		},
+		[]byte{ // invalid PoW
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xe0, 0xf3, // Nonce
+			0x00, 0x00, 0x00, 0xff, 0x49, 0x5f, 0xab, 0x29, // 64-bit Timestamp
+			0x00, 0x00, 0x00, 0x00, // object type
+			0x03, // Version
+			0x01, // Stream Number
+		},
+	}
+
+	for i, test := range errorTests {
+		err = client.Call(rpcHandleSendObject,
+			base64.StdEncoding.EncodeToString(test), nil)
+		if err == nil {
+			t.Errorf("for case #%d got no error", i)
+		}
+	}
+
+	// Insert valid object.
+	data := wire.EncodeMessage(testObj[0]) // getpubkey
+	err = client.Call(rpcHandleSendObject,
+		base64.StdEncoding.EncodeToString(data), nil)
+	if err != nil {
+		t.Errorf("for valid SendObject got error %v", err)
+	}
+	hash, _ := wire.NewShaHash(bmutil.CalcInventoryHash(data))
+
+	// Check if advertised.
+	if ok, err := serv.objectManager.haveInventory(wire.NewInvVect(hash)); !ok {
+		t.Error("server doesn't have new object in inventory, error:", err)
+	}
+}
+
+func testRPCSubscriptions(client *rpc2.Client, t *testing.T) {
+	// Test if old objects are sent OK when subscribing.
+	var received int32
+
+	// Receive Getpubkey inserted in previous test.
+	client.Handle(rpcClientHandleGetpubkey, func(client *rpc2.Client,
+		args *RPCReceiveArgs, _ *struct{}) error {
+		b, err := base64.StdEncoding.DecodeString(args.Object)
+		if err != nil {
+			t.Fatal("invalid base64 encoding")
+		}
+		data := wire.EncodeMessage(testObj[0]) // getpubkey
+		if !bytes.Equal(data, b) {
+			t.Errorf("invalid getpubkey bytes, expected %v got %v", data, b)
+		}
+		t.Logf("Received getpubkey: counter=%d, byte length=%d\n", args.Counter,
+			len(b))
+		atomic.StoreInt32(&received, 1)
+		return nil
+	})
+
+	err := client.Call(rpcHandleSubscribeGetpubkeys, subscribeArgs, nil)
+	if err != nil {
+		t.Error("SubscribeGetpubkeys failed: ", err)
+	}
+
+	// Wait for received==1
+	timer := time.NewTimer(time.Millisecond * 20)
+	<-timer.C
+
+	if atomic.LoadInt32(&received) != 1 {
+		t.Error("did not receive getpubkey from sendOldObjects")
+	}
+
+	// Test if objects inserted after subscribing are handled correctly.
+	atomic.StoreInt32(&received, 0)
+	data := wire.EncodeMessage(testObj[2]) // pubkey
+
+	client.Handle(rpcClientHandlePubkey, func(client *rpc2.Client,
+		args *RPCReceiveArgs, _ *struct{}) error {
+		b, err := base64.StdEncoding.DecodeString(args.Object)
+		if err != nil {
+			t.Fatal("invalid base64 encoding")
+		}
+		if !bytes.Equal(data, b) {
+			t.Errorf("invalid pubkey bytes, expected %v got %v", data, b)
+		}
+		t.Logf("Received pubkey: counter=%d, byte length=%d\n", args.Counter,
+			len(b))
+		atomic.StoreInt32(&received, 1)
+		return nil
+	})
+
+	err = client.Call(rpcHandleSubscribePubkeys, subscribeArgs, nil)
+	if err != nil {
+		t.Error("SubscribePubkeys failed: ", err)
+	}
+
+	err = client.Call(rpcHandleSendObject,
+		base64.StdEncoding.EncodeToString(data), nil)
+	if err != nil {
+		t.Errorf("for valid SendObject got error %v", err)
+	}
+
+	timer.Reset(time.Millisecond * 20)
+	<-timer.C
+	timer.Stop()
+
+	if atomic.LoadInt32(&received) != 1 {
+		t.Error("did not receive pubkey from handleSubscribe")
+	}
+}
+
+func TestRPCConnection(t *testing.T) {
+	// Address for mock listener to pass to server. The server
+	// needs at least one listener or it won't start so we mock it.
+	remoteAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8442}
+
+	// Generate config.
+	var err error
+	cfg, _, err = loadConfig(true)
+	if err != nil {
+		t.Fatal("failed to load config")
+	}
+	cfg.MaxPeers = 0
+	cfg.RPCPass = rpcAdminUser
+	cfg.RPCUser = rpcAdminPass
+	cfg.RPCLimitUser = rpcLimitUser
+	cfg.RPCLimitPass = rpcLimitPass
+	cfg.DisableRPC = false
+	cfg.DisableTLS = true
+	cfg.RPCMaxClients = 1
+
+	// Load rpc listeners.
+	addrs, err := net.LookupHost("localhost")
+	if err != nil {
+		t.Fatal("Could not look up localhost.")
+	}
+	cfg.RPCListeners = make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		addr = net.JoinHostPort(addr, defaultRPCPort)
+		cfg.RPCListeners = append(cfg.RPCListeners, addr)
+	}
+	defer backendLog.Flush()
+
+	// Create a server.
+	listeners := []string{net.JoinHostPort("", "8445")}
+	serv, err = newServer(listeners, getMemDb([]wire.Message{}),
+		MockListen([]*MockListener{
+			NewMockListener(remoteAddr, make(chan peer.Connection), make(chan struct{}, 1))}))
+
+	if err != nil {
+		t.Fatalf("Server creation failed: %s", err)
+	}
+
+	serv.start([]*DefaultPeer{})
+
+	ws, _, err := websocket.DefaultDialer.Dial(rpcLoc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(ws.UnderlyingConn()))
+
+	go client.Run()
+
+	rpcTests(client, t)
+	client.Close() // we're done
+	ws.Close()
+
+	// Test for authentication timeout.
+	ws, _, err = websocket.DefaultDialer.Dial(rpcLoc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client = rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(ws.UnderlyingConn()))
+	go client.Run()
+
+	// wait, give 10ms wiggling room
+	<-time.NewTimer(time.Second*rpcAuthTimeoutSeconds + time.Millisecond*10).C
+
+	select {
+	case <-client.DisconnectNotify():
+	// do nothing
+	default:
+		t.Error("did not disconnect due to auth timeout")
+	}
+
+	// Test for RPCMaxClients
+	ws, _, err = websocket.DefaultDialer.Dial(rpcLoc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = websocket.DefaultDialer.Dial(rpcLoc, nil)
+	if err == nil {
+		t.Error("RPCMaxClients isn't enforced. Second connection was successful.")
+	}
+
+	// Cleanup.
+	serv.Stop()
+	serv.WaitForShutdown()
+}


### PR DESCRIPTION
Add RPC server for clients to connect to and interact with bmd.

Fixes:
- Update outdated documentation for database.Db.
- Changed sync.Mutex in database.MemDb to sync.RWMutex which is more appropriate.
- Change method signature of Db.FetchObjectsFromCounter to return a map from counter value to object data. This is used for sending objects with corresponding values of counters to the clients.

Depends on:
- https://github.com/monetas/bmd/pull/27
- https://github.com/cenkalti/rpc2
- https://github.com/ishbir/eventemitter (fork of https://github.com/CHH/eventemitter)