### PR TITLE
ObjectMsg

### DIFF
--- a/database/memdb/memdb_test.go
+++ b/database/memdb/memdb_test.go
@@ -39,7 +39,7 @@ func TestClosed(t *testing.T) {
 		t.Errorf("RollbackClose: unexpected error %v", err)
 	}
 
-	if _, err := db.InsertObject([]byte{0, 0}); err != database.ErrDbClosed {
+	if _, err := db.InsertObject(nil); err != database.ErrDbClosed {
 		t.Errorf("InsertObject: unexpected error %v", err)
 	}
 

--- a/peer.go
+++ b/peer.go
@@ -217,11 +217,7 @@ func (p *bmpeer) PushObjectMsg(sha *wire.ShaHash) {
 		return
 	}
 
-	msg, err := wire.DecodeMsgObject(obj)
-	if err != nil {
-		return
-	}
-	p.QueueMessage(msg)
+	p.QueueMessage(obj)
 }
 
 // PushAddrMsg sends one, or more, addr message(s) to the connected peer using
@@ -399,7 +395,7 @@ func (p *bmpeer) HandleGetDataMsg(msg *wire.MsgGetData) error {
 
 // HandleObjectMsg updates the peer's request list and sends the object to
 // the object manager.
-func (p *bmpeer) HandleObjectMsg(msg wire.Message) error {
+func (p *bmpeer) HandleObjectMsg(msg *wire.MsgObject) error {
 	if !p.HandshakeComplete() {
 		return errors.New("Handshake not complete.")
 	}
@@ -468,7 +464,7 @@ func (p *bmpeer) handleInitialConnection() {
 
 	// Send a big inv message.
 	hashes, _ := p.server.db.FetchRandomInvHashes(wire.MaxInvPerMsg,
-		func(*wire.ShaHash, []byte) bool { return true })
+		func(*wire.ShaHash, *wire.MsgObject) bool { return true })
 	invVectList := make([]*wire.InvVect, len(hashes))
 	for i, hash := range hashes {
 		invVectList[i] = &wire.InvVect{Hash: hash}

--- a/peer/connection.go
+++ b/peer/connection.go
@@ -93,7 +93,7 @@ func (pc *connection) ReadMessage() (wire.Message, error) {
 	pc.receivedMtx.Unlock()
 
 	if err != nil {
-		if pc.conn == nil { //Connection might have been closed while reading.
+		if pc.conn == nil { // Connection might have been closed while reading.
 			return nil, nil
 		}
 		pc.Close()

--- a/peer/listener_test.go
+++ b/peer/listener_test.go
@@ -112,9 +112,11 @@ func TestConnectionAndListener(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error returned reading message.")
 		}
+		msgObj, _ := wire.ToMsgObject(msg)
+		hashtest := msgObj.InventoryHash()
 
-		hashtest := wire.MessageHash(msg)
-		hashexp := wire.MessageHash(message1)
+		expObj, _ := wire.ToMsgObject(message1)
+		hashexp := expObj.InventoryHash()
 
 		if !hashexp.IsEqual(hashtest) {
 			t.Errorf("Wrong mock connection somehow returned?")
@@ -165,8 +167,11 @@ func TestConnectionAndListener(t *testing.T) {
 	// Write a message to the connection.
 	msg := mockConn.MockRead()
 
-	hashtest := wire.MessageHash(msg)
-	hashexp := wire.MessageHash(message2)
+	msgObj, _ := wire.ToMsgObject(msg)
+	hashtest := msgObj.InventoryHash()
+
+	expObj, _ := wire.ToMsgObject(message2)
+	hashexp := expObj.InventoryHash()
 
 	if !hashexp.IsEqual(hashtest) {
 		t.Errorf("Wrong message sent.")

--- a/peer/logic.go
+++ b/peer/logic.go
@@ -19,7 +19,7 @@ type Logic interface {
 	HandleAddrMsg(*wire.MsgAddr) error
 	HandleInvMsg(*wire.MsgInv) error
 	HandleGetDataMsg(*wire.MsgGetData) error
-	HandleObjectMsg(wire.Message) error
+	HandleObjectMsg(*wire.MsgObject) error
 
 	PushVersionMsg()
 	PushVerAckMsg()

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -170,7 +170,8 @@ out:
 			err = p.logic.HandleGetDataMsg(msg)
 
 		case *wire.MsgGetPubKey, *wire.MsgPubKey, *wire.MsgMsg, *wire.MsgBroadcast, *wire.MsgUnknownObject:
-			err = p.logic.HandleObjectMsg(rmsg)
+			objMsg, _ := wire.ToMsgObject(rmsg)
+			err = p.logic.HandleObjectMsg(objMsg)
 
 		case *wire.MsgPong:
 

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -102,7 +102,7 @@ func (L *MockLogic) HandleGetDataMsg(*wire.MsgGetData) error {
 	return nil
 }
 
-func (L *MockLogic) HandleObjectMsg(wire.Message) error {
+func (L *MockLogic) HandleObjectMsg(*wire.MsgObject) error {
 	if L.Failure || L.Report(MessageTypeObject) {
 		return errors.New("Logic is set to return errors.")
 	}

--- a/peer/send.go
+++ b/peer/send.go
@@ -335,16 +335,10 @@ func NewSend(inventory *Inventory, db database.Db) Send {
 // retrieveObject retrieves an object from the database and decodes it.
 // TODO we actually end up decoding the message and then encoding it again when
 // it is sent. That is not necessary.
-func retrieveObject(db database.Db, inv *wire.InvVect) wire.Message {
+func retrieveObject(db database.Db, inv *wire.InvVect) *wire.MsgObject {
 	obj, err := db.FetchObjectByHash(&inv.Hash)
 	if err != nil {
 		return nil
 	}
-
-	msg, err := wire.DecodeMsgObject(obj)
-	if err != nil {
-		return nil
-	}
-
-	return msg
+	return obj
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8,12 +8,10 @@
 package main
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	prand "math/rand"
 	"net"
@@ -266,18 +264,13 @@ func (s *rpcServer) restrictAdmin(client *rpc2.Client) error {
 
 // NotifyObject is used to notify the RPC server of any new objects so that it
 // can send those onwards to the client.
-func (s *rpcServer) NotifyObject(msg []byte, counter uint64) {
-	// Find type of object.
-	_, _, objType, _, _, err := wire.DecodeMsgObjectHeader(bytes.NewReader(msg))
-	if err != nil {
-		panic(fmt.Sprintf("invalid object: %v", err))
-	}
+func (s *rpcServer) NotifyObject(msg *wire.MsgObject, counter uint64) {
 	out := &RPCReceiveArgs{
-		Object:  base64.StdEncoding.EncodeToString(msg),
+		Object:  base64.StdEncoding.EncodeToString(wire.EncodeMessage(msg)),
 		Counter: counter,
 	}
 
-	switch objType {
+	switch msg.ObjectType {
 	case wire.ObjectTypeBroadcast:
 		s.evtMgr.Emit(rpcEvtNewBroadcast, out)
 	case wire.ObjectTypeGetPubKey:

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cenkalti/rpc2/jsonrpc"
 	"github.com/gorilla/websocket"
 	"github.com/monetas/bmd/peer"
-	"github.com/monetas/bmutil"
 	"github.com/monetas/bmutil/wire"
 )
 
@@ -148,7 +147,7 @@ func testRPCSendObject(client *rpc2.Client, t *testing.T) {
 	if err != nil {
 		t.Errorf("for valid SendObject got error %v", err)
 	}
-	hash, _ := wire.NewShaHash(bmutil.CalcInventoryHash(data))
+	hash := testObj[0].InventoryHash()
 
 	// Check if advertised.
 	if ok, err := serv.objectManager.haveInventory(wire.NewInvVect(hash)); !ok {
@@ -263,7 +262,7 @@ func TestRPCConnection(t *testing.T) {
 
 	// Create a server.
 	listeners := []string{net.JoinHostPort("", "8445")}
-	serv, err = newServer(listeners, getMemDb([]wire.Message{}),
+	serv, err = newServer(listeners, getMemDb([]*wire.MsgObject{}),
 		MockListen([]*MockListener{
 			NewMockListener(remoteAddr, make(chan peer.Connection), make(chan struct{}, 1))}))
 


### PR DESCRIPTION
Changed everything pertaining to objects to be of type wire.MsgObject. The aim is to simplify handling of object messages.

Depends on:
https://github.com/monetas/bmutil/pull/15