### PR TITLE
Bug fixes making initial download work. Object manager downloads from multiple peers simultaneously. Program is stable as far as I know. 

### DIFF
--- a/log.go
+++ b/log.go
@@ -38,6 +38,7 @@ var (
 	rpcLog     = btclog.Disabled
 	serverLog  = btclog.Disabled
 	dbLog      = btclog.Disabled
+	objmgrLog  = btclog.Disabled
 )
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -48,6 +49,7 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"RPC":     rpcLog,
 	"SERVER":  serverLog,
 	"DB":      dbLog,
+	"OBJMGR":  objmgrLog,
 }
 
 // logClosure is used to provide a closure over expensive logging operations
@@ -96,6 +98,9 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 	case "DB":
 		dbLog = logger
 		database.UseLogger(logger)
+
+	case "OBJMGR":
+		objmgrLog = logger
 	}
 }
 

--- a/peer/connection.go
+++ b/peer/connection.go
@@ -195,6 +195,7 @@ func NewConnection(addr net.Addr, maxDown, maxUp int64) Connection {
 
 	pc.idleTimer = time.AfterFunc(pc.idleTimeout, func() {
 		pc.WriteMessage(&wire.MsgPong{})
+		pc.idleTimer.Reset(pc.idleTimeout)
 	})
 
 	pc.idleTimer.Stop()

--- a/peer/internal_test.go
+++ b/peer/internal_test.go
@@ -52,7 +52,11 @@ func TstSwapListen(f func(string, string) (net.Listener, error)) func(string, st
 
 // TstRetrieveObject exposes retrieveObject for testing purposes.
 func TstRetrieveObject(db database.Db, inv *wire.InvVect) wire.Message {
-	return retrieveObject(db, inv)
+	obj := retrieveObject(db, inv)
+	if obj == nil {
+		return nil
+	}
+	return obj
 }
 
 // tstStart is a special way to start the Send without starting the queue

--- a/peer/mruinvmap_test.go
+++ b/peer/mruinvmap_test.go
@@ -27,26 +27,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestString(t *testing.T) {
-	hasha, _ := wire.NewShaHash([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
-	hashb, _ := wire.NewShaHash([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200})
-	a := &wire.InvVect{Hash: *hasha}
-	b := &wire.InvVect{Hash: *hashb}
-
-	m := peer.NewMruInventoryMap(2)
-	m.Add(a)
-	m.Add(b)
-
-	// No good way to actually test that the string comes out right.
-	str := m.String()
-	//t.Error("String expected:",str)
-
-	if str[:74] != "<2>map[{0000000000000000000000000000000000000000000000000000000000000001}:" &&
-		str[87:154] != "{00000000000000000000000000000000000000000000000000000000000000c8}:" {
-		t.Error("Incorrect string returned.")
-	}
-}
-
 // TestMruInvMap tests Exists, Add, and Delete.
 func TestMruInvMap(t *testing.T) {
 	a := &wire.InvVect{Hash: *randomShaHash()}

--- a/peer/send.go
+++ b/peer/send.go
@@ -87,12 +87,8 @@ func (send *send) QueueMessage(msg wire.Message) error {
 		return errors.New("Not running.")
 	}
 
-	select {
-	case send.msgQueue <- msg:
-		return nil
-	default:
-		return errors.New("Message queue full.")
-	}
+	send.msgQueue <- msg
+	return nil
 }
 
 // QueueDataRequest queues a list of invs whose corresponding objects
@@ -103,12 +99,8 @@ func (send *send) QueueDataRequest(inv []*wire.InvVect) error {
 		return errors.New("Not running.")
 	}
 
-	select {
-	case send.requestQueue <- inv:
-		return nil
-	default:
-		return errors.New("Data request queue full.")
-	}
+	send.requestQueue <- inv
+	return nil
 }
 
 // QueueInventory queues new inventory to be trickled periodically
@@ -118,12 +110,8 @@ func (send *send) QueueInventory(inv []*wire.InvVect) error {
 		return errors.New("Not running.")
 	}
 
-	select {
-	case send.outputInvChan <- inv:
-		return nil
-	default:
-		return errors.New("Inventory queue full.")
-	}
+	send.outputInvChan <- inv
+	return nil
 }
 
 // Start starts the send with a new connection.
@@ -263,8 +251,8 @@ out:
 				send.msgQueue <- invMsg
 			}
 
-			// Randomize the number of seconds from 4 to 16 minutes.
-			trickle.Reset(time.Duration(240000 + randTime.Int63n(720000)))
+			// Randomize the number of seconds from 20 to 60 seconds.
+			trickle.Reset(time.Second * (20 + time.Duration(randTime.Int63n(40))))
 		}
 	}
 


### PR DESCRIPTION
The object manager now downloads large lists of invs from other peers more intelligently and there are a number of bug fixes. 

* When an inv is processed by the object manager, if it is too big to be processed by the peer that requested in all at once, the object manager goes through all the peers and apportions invs to them until they are all full or until there are no invs left.
* Peers report to the object manager when they are ready to download more objects.
* If a peer is disconnected, all invs assigned to it are reassigned to other peers. 
* When the peers are all done working, any remaining invs which no peer knows about are deleted from the set of unknown invs. 
* There was a very complicated bug that caused the object manager to lock up when its message channel filled up. This happened during the initial download when several object requests would expire at once. The object manager would then send a disconnect request to the peer for every single one, and for each one the peer would send a handledonepeer message back to the object manager! This is resolved by ensuring that the object manager only tells a peer to disconnect once and ensuring that the peer only calls DonePeer on the object manager once and ensuring that the object manager only tells the peer to disconnect once. This became especially convoluted when several peers are downloading at once because then the object manager could send a disconnect request to each peer. If more than one peer needs to be disconnected at once, a separate go routine is started that disconnects them one by one. I have also made the object manager more lenient about expired requests during the initial download. The original problem was caused by invalid timestamps that recorded when a peer last received an object. For some reason the times are recorded properly when I log them. I am still researching why this would happen, but I hypothesize that it has to do with the way go optimizes its processes. 
* Instead of relaying invs immediately, the object manager stores them and relays the whole list every 10 seconds. This works fine because the peers don't relay new invs immediately either but randomize the time. This also fixes a bug which caused the peers to relay new invs much too quickly because I confused a microsecond with a nanosecond. Now the new inv is relayed randomly every 20 to 60 seconds. 
* There is a new option for request timeout, ie the time at which an object request is considered to have expired. It is set by default at 3 minutes. 
* Finally, I fixed the issue with the pong timeout https://github.com/monetas/bmd/issues/28. I used a timer rather than a ticker because the ticker needs to be reset every time a message is sent. However, I forgot to make the ticker reset itself, which it does now. 

Originally MaxPeerRequests was going to be a command-line option, but I don't think there is any reason a user would want to adjust it. It can cause problems if it is very low or very high, but any number in the middle ought to work fine. Right now it is a constant set at 120. 