### PR TITLE
Resolved many race conditions.

### DIFF
--- a/peer/inventory.go
+++ b/peer/inventory.go
@@ -48,7 +48,7 @@ func (I *Inventory) AddRequest(i int) {
 
 // NumRequests is the number of object download requests that have been made.
 func (I *Inventory) NumRequests() int {
-	return int(I.requested)
+	return int(atomic.LoadInt32(&I.requested))
 }
 
 // FilterKnown takes a list of InvVects, adds them to the list of known

--- a/server.go
+++ b/server.go
@@ -233,25 +233,6 @@ func (s *server) handleBanPeerMsg(p *bmpeer) {
 	s.state.banned[host] = time.Now().Add(cfg.BanDuration)
 }
 
-// handleRelayInvMsg deals with relaying inventory to peers that are not already
-// known to have it. It is invoked from the peerHandler goroutine.
-func (s *server) handleRelayInvMsg(inv []*wire.InvVect) {
-	s.state.forAllPeers(func(p *bmpeer) {
-		if p.peer.Connected() && p.invReceived {
-			ivl := p.inventory.FilterKnown(inv)
-
-			if len(ivl) == 0 {
-				return
-			}
-
-			// Queue the inventory to be relayed with the next batch.
-			// It will be ignored if the peer is already known to
-			// have the inventory.
-			p.send.QueueInventory(ivl)
-		}
-	})
-}
-
 type getConnCountMsg struct {
 	reply chan int32
 }


### PR DESCRIPTION
This pr resolves a number of race conditions found with the go race detector. Most of them are inherent in the tests, but some were in the actual program. In particular, the connection object had a number of problems because different goroutines normally call the read and write methods. 

The object manager now has only one goroutine which is unbuffered and doesn't ever send messages to itself. This is an improvement because it means that new objects are more likely to be handled promptly and it also means that if it fails it will be a lot more obvious what is going wrong. There is also a higher probability that it doesn't have some unknown problem that will sneak up when we least expect it. I think this may also help with the problem of requests timing out inappropriately. 

Other race conditions were resolved by
* making sure that the tests handled the config file properly. 
* removing unnecessary goroutines from the test and running the code in the regular test routine. 

There is one race condition I know of which I didn't resolve and which I wrote about as an issue. However, I have not seen it come up since so it might have been fixed incidentally. 