### PR TITLE
Fixed bug that causes the server to run out of peers eventually. 

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -172,6 +172,7 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 	}
 
 	addr := NetAddressKey(netAddr)
+	// Is the address already known to the address manager?
 	ka := a.find(netAddr)
 	if ka != nil {
 		// TODO(oga) only update addresses periodically.
@@ -217,9 +218,14 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 		// XXX time penalty?
 	}
 
-	bucket := a.getNewBucket(netAddr, srcAddr)
+	// If we get to this part of the function, then netAddr is not in a tried
+	// bucket and might be in one or more new buckets. If this is the first time
+	// we've seen the address, then it will not be in any bucket. If it is already
+	// in a new bucket, it might be added to anothter new bucket.
 
-	// Already exists?
+	// This is a random number, but it might happen to be the same as it was
+	// before.
+	bucket := a.getNewBucket(netAddr, srcAddr)
 	if _, ok := a.addrNew[bucket][addr]; ok {
 		return
 	}
@@ -235,7 +241,7 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 	a.addrNew[bucket][addr] = ka
 
 	log.Tracef("Added new address %s for a total of %d addresses", addr,
-		a.nTried+a.nNew)
+		a.nNew+a.nTried)
 }
 
 // expireNew makes space in the new buckets by expiring the really bad entries.

--- a/config.go
+++ b/config.go
@@ -36,8 +36,8 @@ const (
 	defaultDbType         = "memdb"
 	defaultPort           = 8444
 	defaultRPCPort        = 8442
-	defaultMaxUpPerPeer   = 1024 * 1024 // 1MBps
-	defaultMaxDownPerPeer = 1024 * 1024
+	defaultMaxUpPerPeer   = 2 * 1024 * 1024 // 2MBps
+	defaultMaxDownPerPeer = 2 * 1024 * 1024 // 2MBps
 	defaultMaxOutbound    = 10
 	defaultRequestTimeout = time.Minute * 3
 )

--- a/peer/send.go
+++ b/peer/send.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	// queueSize is the size of data and message queues. TODO arbitrarily set as
-	// 20.
-	queueSize = 20
+	// sendQueueSize is the size of data and message queues. The number should be
+	// small if possible, and ideally we would use an unbuffered channel eventually.
+	sendQueueSize = 5
 )
 
 // Send handles everything that is to be sent to the remote peer eventually.
@@ -309,8 +309,8 @@ func (send *send) PrependAddr(str string) string {
 func NewSend(inventory *Inventory, db database.Db) Send {
 	return &send{
 		trickleTime:   time.Second * 10,
-		msgQueue:      make(chan wire.Message, queueSize),
-		dataQueue:     make(chan wire.Message, queueSize),
+		msgQueue:      make(chan wire.Message, sendQueueSize),
+		dataQueue:     make(chan wire.Message, sendQueueSize),
 		outputInvChan: make(chan []*wire.InvVect, outputBufferSize),
 		requestQueue:  make(chan []*wire.InvVect, outputBufferSize),
 		quit:          make(chan struct{}),

--- a/peer_test.go
+++ b/peer_test.go
@@ -976,7 +976,11 @@ func TestOutboundPeerHandshake(t *testing.T) {
 			InteractionComplete: true,
 			DisconnectExpected:  true,
 		},
-		// TODO send more improperly timed messages here. GetData, inv, and object all need to be tested for disconnection.
+		&PeerAction{
+			Messages:            []wire.Message{testObj[0]},
+			InteractionComplete: true,
+			DisconnectExpected:  true,
+		},
 	}
 
 	localAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
@@ -994,6 +998,7 @@ func TestOutboundPeerHandshake(t *testing.T) {
 
 	for testCase, response := range responses {
 		defer resetCfg(cfg)()
+
 		NewConn = handshakePeerBuilder(response)
 
 		// Create server and start it.
@@ -1089,6 +1094,7 @@ func TestInboundPeerHandshake(t *testing.T) {
 
 	for testCase, open := range openingMsg {
 		defer resetCfg(cfg)()
+
 		// Create server and start it.
 		listeners := []string{net.JoinHostPort("", "8445")}
 		var err error


### PR DESCRIPTION
This pr comprises a number of changes that resulted from my investigations into bmd's behavioral problems.

* Fixed bug that causes the server to run out of peers eventually. The problem was caused a map called outboundGroups which tracked the kinds of ip addresses that the server was connected to. This map was updated correctly when a peer joined but not when it disconnected. Consequently, the server eventually reached a state where it could not connect to any address because every one was already registered in outboundGroups. 
* Fixed bug that caused the object manager not to receive the message that a peer is ready to download more. There was on oversight in one of my previous prs in which I forgot to uncomment some lines in peer.go that had been written in anticipation of the object manager being able to download from many peers at once. As a result, the peers do not signal when they are ready to start downloading again. 
* Added comments to addrmgr.updateAddress because that function is extremely confusing. 
* Added a channel to server that that is used to send a message to disconnect a peer. The object manager needs to do this because it can lock up if it tries to disconnect a peer from its own goroutine. 
* There is a problem in which the objectmanager sometimes disconnects several peers at once for expired requests. I think this problem has to do with channel buffers that are too large and which can end up holding messages for a very long time. In general, if we can get by with shorter channel buffers, we should. My previous pr allowed the object manager to function with an unbuffered channel. This one reduces the buffer size on the sendQueue from 20 to 5. I'm not sure the issue has been entirely resolved but it seems to be improved a lot. More experimentation will have to be done to resolve this problem completely. 