### PR TITLE
Fix --onion, RPC server and database

### DIFF
--- a/README_RPC.md
+++ b/README_RPC.md
@@ -32,9 +32,9 @@ func ReceivePubkey(object []byte, counter uint64)
 func ReceiveUnknownObject(object []byte, counter uint64)
 ```
 Receive objects of the given type from the server. Order of receiving objects
-(especially the initial unsynchronized ones) may be random. Client
-implementations must not rely on sequential values of counter. However, values
-of counter are guaranteed to be unique.
+is guaranteed to be sequential. Moreover, counter values for a particular object
+type are guaranteed to be unique. However, the same object may be sent twice
+(in a rare race condition).
 
 ## RPC Calls
 -----------

--- a/config.go
+++ b/config.go
@@ -722,7 +722,7 @@ func loadConfig(isTest bool) (*config, []string, error) {
 // one was specified, but will otherwise use the normal dial function (which
 // could itself use a proxy or not).
 func bmdDial(network, address string) (net.Conn, error) {
-	if strings.HasSuffix(address, ".onion") {
+	if strings.Contains(address, ".onion:") {
 		return cfg.oniondial(network, address)
 	}
 	return cfg.dial(network, address)

--- a/database/db.go
+++ b/database/db.go
@@ -103,12 +103,18 @@ type Db interface {
 	// RemoveExpiredObjects prunes all objects in the main circulation store
 	// whose expiry time has passed (along with a margin of 3 hours). This does
 	// not touch the pubkeys stored in the public key collection.
-	RemoveExpiredObjects() error
+	RemoveExpiredObjects() ([]*wire.ShaHash, error)
 
-	// RemovePubKey removes a PubKey from the PubKey store with the specified
-	// tag. Note that it doesn't touch the general object store and won't remove
-	// the public key from there.
-	RemovePubKey(*wire.ShaHash) error
+	// RemoveEncryptedPubKey removes a v4 PubKey with the specified tag from the
+	// encrypted PubKey store. Note that it doesn't touch the general object
+	// store and won't remove the public key from there.
+	RemoveEncryptedPubKey(*wire.ShaHash) error
+
+	// RemovePublicIdentity removes the public identity corresponding the given
+	// address from the database. This includes any v2/v3/previously used v4
+	// identities. Note that it doesn't touch the general object store and won't
+	// remove the public key object from there.
+	RemovePublicIdentity(*bmutil.Address) error
 
 	// RollbackClose discards the recent database changes to the previously
 	// saved data at last Sync and closes the database.

--- a/database/memdb/memdb_test.go
+++ b/database/memdb/memdb_test.go
@@ -8,7 +8,6 @@
 package memdb_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/monetas/bmd/database"
@@ -25,7 +24,6 @@ func TestClosed(t *testing.T) {
 	}
 
 	db.Close()
-	hash, _ := wire.NewShaHash(bytes.Repeat([]byte{0}, 32))
 
 	if err := db.Sync(); err != database.ErrDbClosed {
 		t.Errorf("Sync: unexpected error %v", err)
@@ -43,19 +41,19 @@ func TestClosed(t *testing.T) {
 		t.Errorf("InsertObject: unexpected error %v", err)
 	}
 
-	if _, err = db.ExistsObject(hash); err != database.ErrDbClosed {
+	if _, err = db.ExistsObject(nil); err != database.ErrDbClosed {
 		t.Errorf("ExistsObject: unexpected error %v", err)
 	}
 
-	if err := db.RemoveObject(hash); err != database.ErrDbClosed {
+	if err := db.RemoveObject(nil); err != database.ErrDbClosed {
 		t.Errorf("RemoveObject: unexpected error %v", err)
 	}
 
-	if _, err := db.FetchObjectByHash(hash); err != database.ErrDbClosed {
+	if _, err := db.FetchObjectByHash(nil); err != database.ErrDbClosed {
 		t.Errorf("FetchObjectByHash: unexpected error %v", err)
 	}
 
-	if err := db.RemoveExpiredObjects(); err != database.ErrDbClosed {
+	if _, err := db.RemoveExpiredObjects(); err != database.ErrDbClosed {
 		t.Errorf("RemoveExpiredObjects: unexpected error %v", err)
 	}
 
@@ -78,8 +76,12 @@ func TestClosed(t *testing.T) {
 		t.Errorf("RemoveObjectByCounter: unexpected error %v", err)
 	}
 
-	if err := db.RemovePubKey(hash); err != database.ErrDbClosed {
-		t.Errorf("RemovePubKey: unexpected error %v", err)
+	if err := db.RemoveEncryptedPubKey(nil); err != database.ErrDbClosed {
+		t.Errorf("RemoveEncryptedPubKey: unexpected error %v", err)
+	}
+
+	if err := db.RemovePublicIdentity(nil); err != database.ErrDbClosed {
+		t.Errorf("RemovePublicIdentity: unexpected error %v", err)
 	}
 
 	if _, err := db.FetchIdentityByAddress(nil); err != database.ErrDbClosed {

--- a/peer/send_test.go
+++ b/peer/send_test.go
@@ -500,8 +500,8 @@ func TestRetrieveObject(t *testing.T) {
 	notThere := &wire.InvVect{Hash: *randomShaHash()}
 
 	// A valid object that will be in the database.
-	goodData := wire.NewMsgUnknownObject(345, time.Now(),
-		wire.ObjectType(4), 1, 1, []byte{77, 82, 53, 48, 96, 1}).ToMsgObject()
+	goodData := wire.NewMsgObject(345, time.Now(),
+		wire.ObjectType(4), 1, 1, []byte{77, 82, 53, 48, 96, 1})
 	goodInv := &wire.InvVect{Hash: *goodData.InventoryHash()}
 	db.InsertObject(goodData)
 

--- a/peer_test.go
+++ b/peer_test.go
@@ -36,6 +36,13 @@ func randomShaHash() *wire.ShaHash {
 	return hash
 }
 
+// toMsgObject is used to return a *wire.MsgObject when it is certain that the
+// input message is encodable as such.
+func toMsgObject(msg wire.Message) *wire.MsgObject {
+	obj, _ := wire.ToMsgObject(msg)
+	return obj
+}
+
 // resetCfg is called to refresh configuration before every test. The returned
 // function is supposed to be called at the end of the test; to clear temp
 // directories.
@@ -46,8 +53,6 @@ func resetCfg(cfg *config) func() {
 	}
 	cfg.DataDir = dir
 	cfg.LogDir = filepath.Join(cfg.DataDir, defaultLogDirname)
-	cfg.RPCKey = filepath.Join(cfg.DataDir, "rpc.key")
-	cfg.RPCCert = filepath.Join(cfg.DataDir, "rpc.cert")
 
 	return func() {
 		os.RemoveAll(dir)
@@ -861,39 +866,39 @@ var ripehash = []wire.RipeHash{
 }
 
 // Some bitmessage objects that we use for testing. Two of each.
-var testObj = []*wire.MsgObject{
-	wire.NewMsgGetPubKey(654, expires, 4, 1, &ripehash[0], &shahash[0]).ToMsgObject(),
-	wire.NewMsgGetPubKey(654, expires, 4, 1, &ripehash[1], &shahash[1]).ToMsgObject(),
+var testObj = []wire.Message{
+	wire.NewMsgGetPubKey(654, expires, 4, 1, &ripehash[0], &shahash[0]),
+	wire.NewMsgGetPubKey(654, expires, 4, 1, &ripehash[1], &shahash[1]),
 	wire.NewMsgPubKey(543, expires, 4, 1, 2, &pubkey[0], &pubkey[1], 3, 5,
-		[]byte{4, 5, 6, 7, 8, 9, 10}, &shahash[0], []byte{11, 12, 13, 14, 15, 16, 17, 18}).ToMsgObject(),
+		[]byte{4, 5, 6, 7, 8, 9, 10}, &shahash[0], []byte{11, 12, 13, 14, 15, 16, 17, 18}),
 	wire.NewMsgPubKey(543, expires, 4, 1, 2, &pubkey[2], &pubkey[3], 3, 5,
-		[]byte{4, 5, 6, 7, 8, 9, 10}, &shahash[1], []byte{11, 12, 13, 14, 15, 16, 17, 18}).ToMsgObject(),
+		[]byte{4, 5, 6, 7, 8, 9, 10}, &shahash[1], []byte{11, 12, 13, 14, 15, 16, 17, 18}),
 	wire.NewMsgMsg(765, expires, 1, 1,
 		[]byte{90, 87, 66, 45, 3, 2, 120, 101, 78, 78, 78, 7, 85, 55, 2, 23},
 		1, 1, 2, &pubkey[0], &pubkey[1], 3, 5, &ripehash[0], 1,
 		[]byte{21, 22, 23, 24, 25, 26, 27, 28},
 		[]byte{20, 21, 22, 23, 24, 25, 26, 27},
-		[]byte{19, 20, 21, 22, 23, 24, 25, 26}).ToMsgObject(),
+		[]byte{19, 20, 21, 22, 23, 24, 25, 26}),
 	wire.NewMsgMsg(765, expires, 1, 1,
 		[]byte{90, 87, 66, 45, 3, 2, 120, 101, 78, 78, 78, 7, 85, 55},
 		1, 1, 2, &pubkey[2], &pubkey[3], 3, 5, &ripehash[1], 1,
 		[]byte{21, 22, 23, 24, 25, 26, 27, 28, 79},
 		[]byte{20, 21, 22, 23, 24, 25, 26, 27, 79},
-		[]byte{19, 20, 21, 22, 23, 24, 25, 26, 79}).ToMsgObject(),
+		[]byte{19, 20, 21, 22, 23, 24, 25, 26, 79}),
 	wire.NewMsgBroadcast(876, expires, 1, 1, &shahash[0],
 		[]byte{90, 87, 66, 45, 3, 2, 120, 101, 78, 78, 78, 7, 85, 55, 2, 23},
-		1, 1, 2, &pubkey[0], &pubkey[1], 3, 5, &ripehash[1], 1,
+		1, 1, 2, &pubkey[0], &pubkey[1], 3, 5, 1,
 		[]byte{27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41},
-		[]byte{42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56}).ToMsgObject(),
+		[]byte{42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56}),
 	wire.NewMsgBroadcast(876, expires, 1, 1, &shahash[1],
 		[]byte{90, 87, 66, 45, 3, 2, 120, 101, 78, 78, 78, 7, 85, 55},
-		1, 1, 2, &pubkey[2], &pubkey[3], 3, 5, &ripehash[0], 1,
+		1, 1, 2, &pubkey[2], &pubkey[3], 3, 5, 1,
 		[]byte{27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40},
-		[]byte{42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55}).ToMsgObject(),
-	wire.NewMsgUnknownObject(345, expires, wire.ObjectType(4), 1, 1, []byte{77, 82, 53, 48, 96, 1}).ToMsgObject(),
-	wire.NewMsgUnknownObject(987, expires, wire.ObjectType(4), 1, 1, []byte{1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 100}).ToMsgObject(),
-	wire.NewMsgUnknownObject(7288, expires, wire.ObjectType(5), 1, 1, []byte{0, 0, 0, 0, 1, 0, 0}).ToMsgObject(),
-	wire.NewMsgUnknownObject(7288, expires, wire.ObjectType(5), 1, 1, []byte{0, 0, 0, 0, 0, 0, 0, 99, 98, 97}).ToMsgObject(),
+		[]byte{42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55}),
+	wire.NewMsgUnknownObject(345, expires, wire.ObjectType(4), 1, 1, []byte{77, 82, 53, 48, 96, 1}),
+	wire.NewMsgUnknownObject(987, expires, wire.ObjectType(4), 1, 1, []byte{1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 100}),
+	wire.NewMsgUnknownObject(7288, expires, wire.ObjectType(5), 1, 1, []byte{0, 0, 0, 0, 1, 0, 0}),
+	wire.NewMsgUnknownObject(7288, expires, wire.ObjectType(5), 1, 1, []byte{0, 0, 0, 0, 0, 0, 0, 99, 98, 97}),
 }
 
 func init() {
@@ -1329,27 +1334,27 @@ func TestProcessInvAndObjectExchange(t *testing.T) {
 		},
 		{ // Only the real peer should request data.
 			[]*wire.MsgObject{},
-			[]*wire.MsgObject{testObj[0], testObj[2], testObj[4], testObj[6], testObj[8]},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[2]), toMsgObject(testObj[4]), toMsgObject(testObj[6]), toMsgObject(testObj[8])},
 			nil,
 		},
 		{ // Neither peer should request data.
-			[]*wire.MsgObject{testObj[0], testObj[2], testObj[4], testObj[6], testObj[8]},
-			[]*wire.MsgObject{testObj[0], testObj[2], testObj[4], testObj[6], testObj[8]},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[2]), toMsgObject(testObj[4]), toMsgObject(testObj[6]), toMsgObject(testObj[8])},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[2]), toMsgObject(testObj[4]), toMsgObject(testObj[6]), toMsgObject(testObj[8])},
 			nil,
 		},
 		{ // Only the mock peer should request data.
-			[]*wire.MsgObject{testObj[0], testObj[2], testObj[4], testObj[6], testObj[8]},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[2]), toMsgObject(testObj[4]), toMsgObject(testObj[6]), toMsgObject(testObj[8])},
 			[]*wire.MsgObject{},
 			nil,
 		},
 		{ // The peers have no data in common, so they should both ask for everything of the other.
-			[]*wire.MsgObject{testObj[1], testObj[3], testObj[5], testObj[7], testObj[9]},
-			[]*wire.MsgObject{testObj[0], testObj[2], testObj[4], testObj[6], testObj[8]},
+			[]*wire.MsgObject{toMsgObject(testObj[1]), toMsgObject(testObj[3]), toMsgObject(testObj[5]), toMsgObject(testObj[7]), toMsgObject(testObj[9])},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[2]), toMsgObject(testObj[4]), toMsgObject(testObj[6]), toMsgObject(testObj[8])},
 			nil,
 		},
 		{ // The peers have some data in common.
-			[]*wire.MsgObject{testObj[0], testObj[3], testObj[5], testObj[7], testObj[9]},
-			[]*wire.MsgObject{testObj[0], testObj[2], testObj[4], testObj[6], testObj[8]},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[3]), toMsgObject(testObj[5]), toMsgObject(testObj[7]), toMsgObject(testObj[9])},
+			[]*wire.MsgObject{toMsgObject(testObj[0]), toMsgObject(testObj[2]), toMsgObject(testObj[4]), toMsgObject(testObj[6]), toMsgObject(testObj[8])},
 			nil,
 		},
 		{


### PR DESCRIPTION
--onion option was broken earlier. Mirrored upstream change btcsuite/btcd#446.

RPC server has now been updated to send objects to clients in strictly sequential order of counters. This was accomplished using heaps. RPC documentation has also been updated to reflect the same.

Method signatures of a few database functions have been changed. RemoveExpiredObjects now returns the list of objects that it pruned from the database. This is going to be useful for the object manager, to remove those objects from the list of advertised objects. PubKey operations have been improved and
ciphering support (now a part of bmutil) has been integrated. Tests for the same have also been added. Storage of public keys has been optimized. Unencrypted and encrypted messages are now stored separately. This is more efficient than storing everything together.