### PR TITLE
Bug fixes. 

### DIFF
--- a/database/memdb/memdb.go
+++ b/database/memdb/memdb.go
@@ -534,7 +534,7 @@ func (db *MemDb) RemoveExpiredObjects() ([]*wire.ShaHash, error) {
 		return nil, database.ErrDbClosed
 	}
 
-	removedHashes := make([]*wire.ShaHash, expiredSliceSize)
+	removedHashes := make([]*wire.ShaHash, 0, expiredSliceSize)
 
 	for hash, obj := range db.objectsByHash {
 		// current time - 3 hours

--- a/peer/connection_test.go
+++ b/peer/connection_test.go
@@ -6,120 +6,33 @@ package peer_test
 
 import (
 	"bytes"
-	"errors"
 	"net"
-	"strconv"
 	"testing"
-	"time"
 
+	"github.com/DanielKrawisz/mocknet"
 	"github.com/monetas/bmd/peer"
 	"github.com/monetas/bmutil/wire"
 )
 
-// MockConn implements the net.Conn interface and is used to test the
-// connection object without connecting to the real internet.
-type MockConn struct {
-	sendChan    chan []byte
-	receiveChan chan []byte
-	done        chan struct{}
-	outMessage  []byte // A message ready to be sent back to the real peer.
-	outPlace    int    //How much of the outMessage that has been sent.
-	localAddr   net.Addr
-	remoteAddr  net.Addr
-	closed      bool
-}
-
-func (mc *MockConn) Close() error {
-	mc.closed = true
-	close(mc.done)
-	return nil
-}
-
-// LocalAddr returns the localAddr field of the fake connection and satisfies
-// the net.Conn interface.
-func (mc *MockConn) LocalAddr() net.Addr {
-	return mc.localAddr
-}
-
-// RemoteAddr returns the remoteAddr field of the fake connection and satisfies
-// the net.Conn interface.
-func (mc *MockConn) RemoteAddr() net.Addr {
-	return mc.remoteAddr
-}
-
-func (mc *MockConn) SetDeadline(t time.Time) error {
-	return nil
-}
-
-func (mc *MockConn) SetReadDeadline(t time.Time) error {
-	return nil
-}
-
-func (mc *MockConn) SetWriteDeadline(t time.Time) error {
-	return nil
-}
-
-// Read allows the real peer to read message from the mock connection.
-func (mc *MockConn) Read(b []byte) (int, error) {
-	if mc.closed {
-		return 0, errors.New("Connection closed.")
-	}
-
-	i := 0
-	for i < len(b) {
-		if mc.outMessage == nil {
-			select {
-			case <-mc.done:
-				return 0, errors.New("Connection closed.")
-			case mc.outMessage = <-mc.receiveChan:
-			}
-			mc.outPlace = 0
-		}
-
-		for mc.outPlace < len(mc.outMessage) && i < len(b) {
-			b[i] = mc.outMessage[mc.outPlace]
-			mc.outPlace++
-			i++
-		}
-
-		if mc.outPlace == len(mc.outMessage) {
-			mc.outMessage = nil
-		}
-	}
-
-	return i, nil
-}
-
-// Write allows the peer to write to the mock connection.
-func (mc *MockConn) Write(b []byte) (n int, err error) {
-	if mc.closed {
-		return 0, errors.New("Connection closed.")
-	}
-
-	data := make([]byte, len(b))
-	copy(data, b)
-	mc.sendChan <- data
-	return len(b), nil
+// MockWrite is for the mock peer to write a message that will be read by
+// the real peer.
+func MockWrite(mc *mocknet.Conn, msg wire.Message) {
+	buf := &bytes.Buffer{}
+	wire.WriteMessage(buf, msg, wire.MainNet)
+	mc.MockWrite(buf.Bytes())
 }
 
 // MockRead is for the mock peer to read a message that has previously
 // been written with Write.
-func (mc *MockConn) MockRead() wire.Message {
-	if mc.closed {
+func MockRead(mc *mocknet.Conn) wire.Message {
+	header := mc.MockRead()
+	if header == nil {
 		return nil
 	}
 
-	var header, body []byte
-	select {
-	case <-mc.done:
+	body := mc.MockRead()
+	if body == nil {
 		return nil
-	case header = <-mc.sendChan:
-	}
-
-	select {
-	case <-mc.done:
-		return nil
-	case body = <-mc.sendChan:
 	}
 
 	b := make([]byte, len(header)+len(body))
@@ -138,39 +51,6 @@ func (mc *MockConn) MockRead() wire.Message {
 	return msg
 }
 
-// MockWrite is for the mock peer to write a message that will be read by
-// the real peer.
-func (mc *MockConn) MockWrite(msg wire.Message) {
-	buf := &bytes.Buffer{}
-	wire.WriteMessage(buf, msg, wire.MainNet)
-	mc.receiveChan <- buf.Bytes()
-}
-
-// NewMockConn creates a new mockConn
-func NewMockConn(localAddr, remoteAddr net.Addr, closed bool) *MockConn {
-	return &MockConn{
-		localAddr:   localAddr,
-		remoteAddr:  remoteAddr,
-		sendChan:    make(chan []byte),
-		receiveChan: make(chan []byte),
-		done:        make(chan struct{}),
-		closed:      closed,
-	}
-}
-
-// dialNewMockConn is a function that can be swapped with the dial var for
-// testing purposes.
-func dialNewMockConn(localAddr net.Addr, fail bool, closed bool) func(service, addr string) (net.Conn, error) {
-	return func(service, addr string) (net.Conn, error) {
-		if fail {
-			return nil, errors.New("Connection failed.")
-		}
-		host, portstr, _ := net.SplitHostPort(addr)
-		port, _ := strconv.ParseInt(portstr, 10, 0)
-		return NewMockConn(localAddr, &net.TCPAddr{IP: net.ParseIP(host), Port: int(port)}, closed), nil
-	}
-}
-
 const (
 	maxUpload   = 10000000
 	maxDownload = 10000000
@@ -180,7 +60,7 @@ func TestDial(t *testing.T) {
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
 	localAddr := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
 
-	d := peer.TstSwapDial(dialNewMockConn(localAddr, false, false))
+	d := peer.TstSwapDial(mocknet.Dialer(localAddr, false, false))
 	defer peer.TstSwapDial(d)
 
 	conn := peer.NewConnection(remoteAddr, maxUpload, maxDownload)
@@ -196,7 +76,7 @@ func TestDial(t *testing.T) {
 		t.Errorf("Expected error for trying to connect twice.")
 	}
 
-	peer.TstSwapDial(dialNewMockConn(localAddr, true, false))
+	peer.TstSwapDial(mocknet.Dialer(localAddr, true, false))
 	conn = peer.NewConnection(remoteAddr, maxUpload, maxDownload)
 	err = conn.Connect()
 	if err == nil {
@@ -210,7 +90,7 @@ func TestUnconnectedConnection(t *testing.T) {
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
 	localAddr := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
 
-	d := peer.TstSwapDial(dialNewMockConn(localAddr, false, false))
+	d := peer.TstSwapDial(mocknet.Dialer(localAddr, false, false))
 	defer peer.TstSwapDial(d)
 
 	conn := peer.NewConnection(remoteAddr, maxUpload, maxDownload)
@@ -233,7 +113,7 @@ func TestInterruptedConnection(t *testing.T) {
 	remoteAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
 	localAddr := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
 
-	d := peer.TstSwapDial(dialNewMockConn(localAddr, false, true))
+	d := peer.TstSwapDial(mocknet.Dialer(localAddr, false, true))
 	defer peer.TstSwapDial(d)
 
 	conn := peer.NewConnection(remoteAddr, maxUpload, maxDownload)

--- a/peer/mruinvmap_test.go
+++ b/peer/mruinvmap_test.go
@@ -5,21 +5,11 @@
 package peer_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/monetas/bmd/peer"
 	"github.com/monetas/bmutil/wire"
 )
-
-func randomShaHash() *wire.ShaHash {
-	b := make([]byte, 32)
-	for i := 0; i < 32; i++ {
-		b[i] = byte(rand.Intn(256))
-	}
-	hash, _ := wire.NewShaHash(b)
-	return hash
-}
 
 func TestNew(t *testing.T) {
 	if peer.NewMruInventoryMap(2) == nil {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -169,7 +169,8 @@ out:
 		case *wire.MsgGetData:
 			err = p.logic.HandleGetDataMsg(msg)
 
-		case *wire.MsgGetPubKey, *wire.MsgPubKey, *wire.MsgMsg, *wire.MsgBroadcast, *wire.MsgUnknownObject:
+		case *wire.MsgGetPubKey, *wire.MsgPubKey, *wire.MsgMsg,
+			*wire.MsgBroadcast, *wire.MsgUnknownObject:
 			objMsg, _ := wire.ToMsgObject(rmsg)
 			err = p.logic.HandleObjectMsg(objMsg)
 

--- a/peer/testobjects_test.go
+++ b/peer/testobjects_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2015 Monetas.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package peer_test
+
+import (
+	"errors"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/monetas/bmutil/wire"
+)
+
+// randomShaHash returns a ShaHash with a random string of bytes in it.
+func randomShaHash() *wire.ShaHash {
+	b := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		b[i] = byte(rand.Intn(256))
+	}
+	hash, _ := wire.NewShaHash(b)
+	return hash
+}
+
+// MockConnection implements the peer.Connection interface and is used to test
+// send without connecting to the real internet.
+type MockConnection struct {
+	closed      bool // Whether the connection has been closed.
+	connected   bool // Whether the connection is connected.
+	failure     bool // When this is true, sending or receiving messages returns an error.
+	connectFail bool // When this is true, the connection cannot connect.
+	done        chan struct{}
+	failChan    chan struct{}
+	reply       chan wire.Message
+	send        chan wire.Message
+	addr        net.Addr
+	mutex       sync.RWMutex
+	failmtx     sync.Mutex
+}
+
+func (mock *MockConnection) WriteMessage(msg wire.Message) error {
+	if mock.closed {
+		return errors.New("Connection closed.")
+	}
+
+	if mock.failure {
+		return errors.New("Mock Connection set to fail.")
+	}
+
+	mock.reply <- msg
+
+	return nil
+}
+
+// MockRead allows for tests as to whether a message has been sent or not.
+// It accepts an extra channel that can be read from if no message has been
+// sent. Normally, Read blocks until a message is received.
+func (mock *MockConnection) MockRead(reset chan struct{}) wire.Message {
+	if mock.closed {
+		return nil
+	}
+
+	select {
+	case <-mock.done:
+		return nil
+	case message := <-mock.reply:
+		return message
+	case <-reset:
+		return nil
+	}
+}
+
+func (mock *MockConnection) ReadMessage() (wire.Message, error) {
+	mock.mutex.RLock()
+	fail := mock.failure
+	mock.mutex.RUnlock()
+
+	if fail {
+		return nil, errors.New("Mock Connection set to fail.")
+	}
+
+	mock.failmtx.Lock()
+	defer mock.failmtx.Unlock()
+
+	select {
+	case msg := <-mock.send:
+		return msg, nil
+	case <-mock.failChan:
+		return nil, errors.New("Mock Connection set to fail.")
+	}
+}
+
+func (mock *MockConnection) MockWrite(msg wire.Message) {
+	mock.send <- msg
+
+}
+
+func (mock *MockConnection) BytesWritten() uint64 {
+	return 0
+}
+
+func (mock *MockConnection) BytesRead() uint64 {
+	return 0
+}
+
+func (mock *MockConnection) LastWrite() time.Time {
+	return time.Time{}
+}
+
+func (mock *MockConnection) LastRead() time.Time {
+	return time.Time{}
+}
+
+func (mock *MockConnection) RemoteAddr() net.Addr {
+	return mock.addr
+}
+
+func (mock *MockConnection) LocalAddr() net.Addr {
+	return nil
+}
+
+func (mock *MockConnection) Close() {
+	if mock.closed {
+		return
+	}
+	mock.closed = true
+	mock.mutex.Lock()
+	mock.connected = false
+	mock.mutex.Unlock()
+	close(mock.done)
+
+	// Drain any incoming messages.
+close:
+	for {
+		select {
+		case <-mock.reply:
+		default:
+			break close
+		}
+	}
+}
+
+func (mock *MockConnection) Connected() bool {
+	mock.mutex.RLock()
+	defer mock.mutex.RUnlock()
+
+	return mock.connected
+}
+
+func (mock *MockConnection) Connect() error {
+	if mock.connectFail {
+		return errors.New("Connection set to fail.")
+	}
+	mock.mutex.Lock()
+	mock.connected = true
+	mock.mutex.Unlock()
+	return nil
+}
+
+func (mock *MockConnection) SetFailure(b bool) {
+	mock.mutex.Lock()
+	mock.failure = b
+	mock.mutex.Unlock()
+
+	if b == true {
+		// Drain any messages being sent now so that WriteMessage will
+		// immediately return an error.
+		select {
+		case <-mock.done:
+		default:
+		}
+
+		// Close the failure channel to ensure any messages being read
+		// will return an error.
+		close(mock.failChan)
+
+	} else {
+		mock.failmtx.Lock()
+		mock.failChan = make(chan struct{})
+		mock.failmtx.Unlock()
+	}
+}
+
+func NewMockConnection(addr net.Addr, connected bool, fails bool) *MockConnection {
+	return &MockConnection{
+		done:        make(chan struct{}),
+		reply:       make(chan wire.Message),
+		send:        make(chan wire.Message),
+		failChan:    make(chan struct{}),
+		connected:   connected,
+		connectFail: fails,
+		addr:        addr,
+	}
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -6,15 +6,12 @@ package main
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,23 +22,6 @@ import (
 	"github.com/monetas/bmutil/pow"
 	"github.com/monetas/bmutil/wire"
 )
-
-// randomShaHash returns a ShaHash with a random string of bytes in it.
-func randomShaHash() *wire.ShaHash {
-	b := make([]byte, 32)
-	for i := 0; i < 32; i++ {
-		b[i] = byte(rand.Intn(256))
-	}
-	hash, _ := wire.NewShaHash(b)
-	return hash
-}
-
-// toMsgObject is used to return a *wire.MsgObject when it is certain that the
-// input message is encodable as such.
-func toMsgObject(msg wire.Message) *wire.MsgObject {
-	obj, _ := wire.ToMsgObject(msg)
-	return obj
-}
 
 // resetCfg is called to refresh configuration before every test. The returned
 // function is supposed to be called at the end of the test; to clear temp
@@ -83,731 +63,6 @@ func tstNewPeerHandshakeComplete(s *server, conn peer.Connection, inventory *pee
 	logic.peer = p
 
 	return logic
-}
-
-// PeerAction represents a an action to be taken by the mock peer and information
-// about the expected response from the real peer.
-type PeerAction struct {
-	// A series of messages to send to the real peer.
-	Messages []wire.Message
-
-	// If an error is set, the interaction ends immediately.
-	Err error
-
-	// Whether the interaction is complete.
-	InteractionComplete bool
-
-	// For negative tests, we expect the peer to disconnect after the interaction is
-	// complete. If disconnectExpected is set, the test fails if the real peer fails
-	// to disconnect after half a second.
-	DisconnectExpected bool
-}
-
-// PeerTest is a type that defines the high-level behavior of a peer.
-type PeerTest interface {
-	OnStart() *PeerAction
-	OnMsgVersion(p *wire.MsgVersion) *PeerAction
-	OnMsgVerAck(p *wire.MsgVerAck) *PeerAction
-	OnMsgAddr(p *wire.MsgAddr) *PeerAction
-	OnMsgInv(p *wire.MsgInv) *PeerAction
-	OnMsgGetData(p *wire.MsgGetData) *PeerAction
-	OnSendData(invVect []*wire.InvVect) *PeerAction
-}
-
-// OutboundHandshakePeerTester is an implementation of PeerTest that is for
-// testing the handshake with an outbound peer.
-type OutboundHandshakePeerTester struct {
-	versionReceived   bool
-	handshakeComplete bool
-	response          *PeerAction
-	msgAddr           wire.Message
-	mutex             sync.RWMutex
-}
-
-func (peer *OutboundHandshakePeerTester) OnStart() *PeerAction {
-	return nil
-}
-
-func (peer *OutboundHandshakePeerTester) VersionReceived() bool {
-	peer.mutex.RLock()
-	defer peer.mutex.RUnlock()
-
-	return peer.versionReceived
-}
-
-func (peer *OutboundHandshakePeerTester) HandshakeComplete() bool {
-	peer.mutex.RLock()
-	defer peer.mutex.RUnlock()
-
-	return peer.handshakeComplete
-}
-
-func (peer *OutboundHandshakePeerTester) OnMsgVersion(version *wire.MsgVersion) *PeerAction {
-	if peer.VersionReceived() {
-		return &PeerAction{Err: errors.New("Two version messages received")}
-	}
-	peer.versionReceived = true
-	return peer.response
-}
-
-func (peer *OutboundHandshakePeerTester) OnMsgVerAck(p *wire.MsgVerAck) *PeerAction {
-	if !peer.VersionReceived() {
-		return &PeerAction{Err: errors.New("Expecting version message first.")}
-	}
-	peer.mutex.Lock()
-	peer.handshakeComplete = true
-	peer.mutex.Unlock()
-	return &PeerAction{
-		Messages:            []wire.Message{peer.msgAddr},
-		InteractionComplete: true,
-		DisconnectExpected:  false,
-	}
-}
-
-func (peer *OutboundHandshakePeerTester) OnMsgAddr(p *wire.MsgAddr) *PeerAction {
-	if peer.HandshakeComplete() {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
-}
-
-func (peer *OutboundHandshakePeerTester) OnMsgInv(p *wire.MsgInv) *PeerAction {
-	if peer.HandshakeComplete() {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
-}
-
-func (peer *OutboundHandshakePeerTester) OnMsgGetData(p *wire.MsgGetData) *PeerAction {
-	if peer.HandshakeComplete() {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
-}
-
-func (peer *OutboundHandshakePeerTester) OnSendData(invVect []*wire.InvVect) *PeerAction {
-	if peer.HandshakeComplete() {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Object message not allowed before handshake is complete.")}
-}
-
-func NewOutboundHandshakePeerTester(action *PeerAction, msgAddr wire.Message) *OutboundHandshakePeerTester {
-	return &OutboundHandshakePeerTester{
-		versionReceived:   false,
-		handshakeComplete: false,
-		response:          action,
-		msgAddr:           msgAddr,
-	}
-}
-
-// InboundHandsakePeerTester implements the PeerTest interface and is used to test
-// handshakes with inbound peers and the exchange of the addr messages.
-type InboundHandshakePeerTester struct {
-	verackReceived    bool
-	versionReceived   bool
-	handshakeComplete bool
-	openMsg           *PeerAction
-	addrAction        *PeerAction
-}
-
-func (peer *InboundHandshakePeerTester) OnStart() *PeerAction {
-	return peer.openMsg
-}
-
-func (peer *InboundHandshakePeerTester) OnMsgVersion(version *wire.MsgVersion) *PeerAction {
-	if peer.versionReceived {
-		return &PeerAction{Err: errors.New("Two versions received?")}
-	}
-	peer.versionReceived = true
-	if peer.verackReceived {
-		// Handshake completed successfully
-		peer.handshakeComplete = true
-
-		// Sending an addr message to make sure the peer doesn't disconnect.
-		return peer.addrAction
-	}
-	return &PeerAction{[]wire.Message{&wire.MsgVerAck{}}, nil, false, false}
-}
-
-func (peer *InboundHandshakePeerTester) OnMsgVerAck(p *wire.MsgVerAck) *PeerAction {
-	if peer.verackReceived {
-		return &PeerAction{Err: errors.New("Two veracks received?")}
-	}
-	peer.verackReceived = true
-	if peer.versionReceived {
-		// Handshake completed successfully
-		peer.handshakeComplete = true
-
-		//Sending an addr message to make sure the peer doesn't disconnect.
-		return peer.addrAction
-	}
-	// Return nothing and await a version message.
-	return &PeerAction{nil, nil, false, false}
-}
-
-func (peer *InboundHandshakePeerTester) OnMsgAddr(p *wire.MsgAddr) *PeerAction {
-	if peer.handshakeComplete {
-		return &PeerAction{nil, nil, true, false}
-	}
-	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
-}
-
-func (peer *InboundHandshakePeerTester) OnMsgInv(p *wire.MsgInv) *PeerAction {
-	if peer.handshakeComplete {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
-}
-
-func (peer *InboundHandshakePeerTester) OnMsgGetData(p *wire.MsgGetData) *PeerAction {
-	if peer.handshakeComplete {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
-}
-
-func (peer *InboundHandshakePeerTester) OnSendData(invVect []*wire.InvVect) *PeerAction {
-	if peer.handshakeComplete {
-		return nil
-	}
-	return &PeerAction{Err: errors.New("Object message not allowed before handshake is complete.")}
-}
-
-func NewInboundHandshakePeerTester(openingMsg *PeerAction, addrAction *PeerAction) *InboundHandshakePeerTester {
-	return &InboundHandshakePeerTester{
-		verackReceived:    false,
-		versionReceived:   false,
-		handshakeComplete: false,
-		openMsg:           openingMsg,
-		addrAction:        addrAction,
-	}
-}
-
-// DataExchangePeerTester implements the PeerTest interface and tests the exchange
-// of inv messages and data.
-type DataExchangePeerTester struct {
-	dataSent      bool
-	dataReceived  bool
-	invReceived   bool
-	invAction     *PeerAction
-	inventory     map[wire.InvVect]*wire.MsgObject // The initial inventory of the mock peer.
-	peerInventory map[wire.InvVect]struct{}        // The initial inventory of the real peer.
-	requested     map[wire.InvVect]struct{}        // The messages that were requested.
-}
-
-func (peer *DataExchangePeerTester) OnStart() *PeerAction {
-	return peer.invAction
-}
-
-func (peer *DataExchangePeerTester) OnMsgVersion(version *wire.MsgVersion) *PeerAction {
-	return &PeerAction{Err: errors.New("This test should begin with handshake already done.")}
-}
-
-func (peer *DataExchangePeerTester) OnMsgVerAck(p *wire.MsgVerAck) *PeerAction {
-	return &PeerAction{Err: errors.New("This test should begin with handshake already done.")}
-}
-
-func (peer *DataExchangePeerTester) OnMsgAddr(p *wire.MsgAddr) *PeerAction {
-	return nil
-}
-
-func (peer *DataExchangePeerTester) OnMsgInv(inv *wire.MsgInv) *PeerAction {
-	if peer.invReceived {
-		return &PeerAction{Err: errors.New("Inv message allready received.")}
-	}
-
-	peer.invReceived = true
-
-	if len(inv.InvList) == 0 {
-		return &PeerAction{Err: errors.New("Empty inv message received.")}
-	}
-
-	if len(inv.InvList) > wire.MaxInvPerMsg {
-		return &PeerAction{Err: errors.New("Excessively long inv message received.")}
-	}
-
-	// Return a get data message that requests the entries in inv which are not already known.
-	i := 0
-	var ok bool
-	duplicate := make(map[wire.InvVect]struct{})
-	newInvList := make([]*wire.InvVect, len(inv.InvList))
-	for _, iv := range inv.InvList {
-		if _, ok = peer.inventory[*iv]; !ok {
-			if _, ok = duplicate[*iv]; ok {
-				return &PeerAction{Err: errors.New("Inv with duplicates received.")}
-			}
-			duplicate[*iv] = struct{}{}
-			newInvList[i] = iv
-			peer.requested[*iv] = struct{}{}
-			i++
-		}
-	}
-
-	if i == 0 {
-		return nil
-	}
-
-	return &PeerAction{
-		Messages: []wire.Message{&wire.MsgGetData{InvList: newInvList[:i]}},
-	}
-}
-
-func (peer *DataExchangePeerTester) OnMsgGetData(getData *wire.MsgGetData) *PeerAction {
-
-	if len(getData.InvList) == 0 {
-		return &PeerAction{Err: errors.New("Empty GetData message received.")}
-	}
-
-	if len(getData.InvList) > wire.MaxInvPerMsg {
-		return &PeerAction{Err: errors.New("Excessively long GetData message received.")}
-	}
-
-	// The getdata message should include no duplicates and should include nothing
-	// that the peer already knows, and nothing that the mock peer doesn't know.
-	i := 0
-	duplicate := make(map[wire.InvVect]struct{})
-	messages := make([]wire.Message, len(getData.InvList))
-	for _, iv := range getData.InvList {
-		msg, ok := peer.inventory[*iv]
-		if !ok {
-			return &PeerAction{Err: errors.New("GetData asked for something we don't know.")}
-		}
-
-		if _, ok = duplicate[*iv]; ok {
-			return &PeerAction{Err: errors.New("GetData with duplicates received.")}
-		}
-
-		duplicate[*iv] = struct{}{}
-		messages[i] = msg
-		peer.peerInventory[*iv] = struct{}{}
-		i++
-	}
-
-	peer.dataSent = true
-
-	if peer.dataReceived {
-		return &PeerAction{messages[:i], nil, true, false}
-	}
-	return &PeerAction{messages[:i], nil, false, false}
-}
-
-func (peer *DataExchangePeerTester) OnSendData(invVect []*wire.InvVect) *PeerAction {
-	if !peer.invReceived {
-		return &PeerAction{Err: errors.New("Object message not allowed before exchange of invs.")}
-	}
-
-	// The objects must have been requested.
-	for _, iv := range invVect {
-		if _, ok := peer.requested[*iv]; !ok {
-			return &PeerAction{Err: errors.New("Object message not allowed before handshake is complete.")}
-		}
-		delete(peer.requested, *iv)
-	}
-
-	if len(peer.requested) == 0 {
-		peer.dataReceived = true
-	}
-
-	if peer.dataReceived && peer.dataSent {
-		return &PeerAction{nil, nil, true, false}
-	}
-	return &PeerAction{nil, nil, false, false}
-}
-
-func NewDataExchangePeerTester(inventory []*wire.MsgObject, peerInventory []*wire.MsgObject, invAction *PeerAction) *DataExchangePeerTester {
-	// Catalog the initial inventories of the mock peer and real peer.
-	in := make(map[wire.InvVect]*wire.MsgObject)
-	pin := make(map[wire.InvVect]struct{})
-	invMsg := wire.NewMsgInv()
-
-	// Construct the real peer's inventory.
-	for _, message := range inventory {
-		inv := wire.InvVect{Hash: *message.InventoryHash()}
-		invMsg.AddInvVect(&inv)
-		in[inv] = message
-	}
-
-	// Construct the mock peer's inventory.
-	for _, message := range peerInventory {
-		inv := wire.InvVect{Hash: *message.InventoryHash()}
-		pin[inv] = struct{}{}
-	}
-
-	dataSent := true
-	dataReceived := true
-
-	// Does the real peer have any inventory that the mock peer does not have?
-	for inv := range in {
-		if _, ok := pin[inv]; !ok {
-			dataSent = false
-			break
-		}
-	}
-
-	// Does the mock peer have any inventory that the real peer does not?
-	for inv := range pin {
-		if _, ok := in[inv]; !ok {
-			dataReceived = false
-			break
-		}
-	}
-
-	var inva *PeerAction
-	if invAction == nil {
-		if len(invMsg.InvList) == 0 {
-			inva = &PeerAction{
-				Messages:            []wire.Message{&wire.MsgVerAck{}},
-				InteractionComplete: dataSent && dataReceived,
-			}
-		} else {
-			inva = &PeerAction{
-				Messages:            []wire.Message{&wire.MsgVerAck{}, invMsg},
-				InteractionComplete: dataSent && dataReceived,
-			}
-		}
-	} else {
-		inva = invAction
-	}
-
-	return &DataExchangePeerTester{
-		dataSent:      dataSent,
-		dataReceived:  dataReceived,
-		inventory:     in,
-		peerInventory: pin,
-		invAction:     inva,
-		requested:     make(map[wire.InvVect]struct{}),
-	}
-}
-
-// The report that the MockConnection sends when its interaction is complete.
-// If the error is nil, then the test has completed successfully.
-// The report also includes any object messages that were sent to the peer.
-type TestReport struct {
-	Err      error
-	DataSent []*wire.ShaHash
-}
-
-// MockConnection implements the Connection interface and
-// is a mock peer to be used for testing purposes.
-type MockConnection struct {
-	// After a message is processed, the replies are sent here.
-	reply chan []wire.Message
-
-	// A channel used to report invalid states to the test.
-	report chan TestReport
-
-	// A function that manages the sequence of steps that the test should go through.
-	// This is the part that is customized for each test.
-	//handle     func(wire.Message) *PeerAction
-	peerTest PeerTest
-
-	// A list of hashes of objects that have been sent to the real peer.
-	objectData []*wire.ShaHash
-
-	// A queue of messages to be received by the real peer.
-	msgQueue []wire.Message
-
-	// The current place in the queue.
-	queuePlace int
-
-	// The test ends when the timer runs out. Until the interaction is complete,
-	// the timer is reset with every message received. Some time is required after
-	// the mock peer is done interacting with the real one to see if the real peer
-	// disconnects or not.
-	timer *time.Timer
-
-	// when interactionComplete is set, the mock peer no longer processes incoming
-	// messages or resets the timer. It is just waiting to see whether the real peer
-	// disconnects.
-	interactionComplete bool
-
-	// Whether the peer is expected to disconnect.
-	disconnectExpected bool
-
-	localAddr  net.Addr
-	remoteAddr net.Addr
-
-	// Whether the report has already been submitted.
-	reported int32
-
-	// A mutex for data that might be accessed by different threads.
-	mutex sync.RWMutex
-}
-
-func (mock *MockConnection) ReadMessage() (wire.Message, error) {
-	// If the queue is empty, get a new message from the channel.
-	for mock.msgQueue == nil || mock.queuePlace >= len(mock.msgQueue) {
-		mock.msgQueue = <-mock.reply
-		mock.queuePlace = 0
-	}
-
-	toSend := mock.msgQueue[mock.queuePlace]
-
-	mock.queuePlace++
-
-	if mock.queuePlace >= len(mock.msgQueue) {
-		mock.msgQueue = nil
-	}
-
-	switch t := toSend.(type) {
-	case *wire.MsgGetPubKey, *wire.MsgPubKey, *wire.MsgMsg, *wire.MsgBroadcast, *wire.MsgUnknownObject:
-		msg, _ := wire.ToMsgObject(t)
-		mock.objectData = append(mock.objectData, msg.InventoryHash())
-	}
-
-	return toSend, nil
-}
-
-// WriteMessage figures out how to respond to a message once it is decyphered.
-func (mock *MockConnection) WriteMessage(rmsg wire.Message) error {
-	// We can keep receiving messages after the interaction is done; we just
-	// ignore them.	 We are waiting to see whether the peer disconnects.
-	mock.mutex.RLock()
-	ic := mock.interactionComplete
-	mock.mutex.RUnlock()
-	if ic {
-		return nil
-	}
-
-	mock.mutex.Lock()
-	mock.timer.Reset(time.Second)
-	mock.mutex.Unlock()
-	mock.handleAction(mock.handleMessage(rmsg))
-	return nil
-}
-
-func (mock *MockConnection) RequestData(invVect []*wire.InvVect) error {
-	// We can keep receiving messages after the interaction is done; we just ignore them.
-	// We are waiting to see whether the peer disconnects.
-	mock.mutex.RLock()
-	ic := mock.interactionComplete
-	mock.mutex.RUnlock()
-	if ic {
-		return nil
-	}
-
-	mock.mutex.Lock()
-	mock.timer.Reset(time.Second)
-	mock.mutex.Unlock()
-	mock.handleAction(mock.peerTest.OnSendData(invVect))
-	return nil
-}
-
-func (mock *MockConnection) BytesWritten() uint64 {
-	return 0
-}
-
-func (mock *MockConnection) BytesRead() uint64 {
-	return 0
-}
-
-func (mock *MockConnection) LastWrite() time.Time {
-	return time.Time{}
-}
-
-func (mock *MockConnection) LastRead() time.Time {
-	return time.Time{}
-}
-
-// LocalAddr returns the localAddr field of the fake connection and satisfies
-// the net.Conn interface.
-func (mock *MockConnection) LocalAddr() net.Addr {
-	return mock.localAddr
-}
-
-// RemoteAddr returns the remoteAddr field of the fake connection and satisfies
-// the net.Conn interface.
-func (mock *MockConnection) RemoteAddr() net.Addr {
-	return mock.remoteAddr
-}
-
-func (mock *MockConnection) Close() {
-	mock.ConnectionClosed()
-}
-
-func (mock *MockConnection) Connected() bool {
-	return true
-}
-
-func (mock *MockConnection) Connect() error {
-	return errors.New("Already connected.")
-}
-
-func (mock *MockConnection) handleMessage(msg wire.Message) *PeerAction {
-	switch msg.(type) {
-	case *wire.MsgVersion:
-		return mock.peerTest.OnMsgVersion(msg.(*wire.MsgVersion))
-	case *wire.MsgVerAck:
-		return mock.peerTest.OnMsgVerAck(msg.(*wire.MsgVerAck))
-	case *wire.MsgAddr:
-		return mock.peerTest.OnMsgAddr(msg.(*wire.MsgAddr))
-	case *wire.MsgInv:
-		return mock.peerTest.OnMsgInv(msg.(*wire.MsgInv))
-	case *wire.MsgGetData:
-		return mock.peerTest.OnMsgGetData(msg.(*wire.MsgGetData))
-	default:
-		return nil
-	}
-}
-
-func (mock *MockConnection) handleAction(action *PeerAction) {
-	// A nil response means to do nothing.
-	if action == nil {
-		return
-	}
-
-	// If an error is returned, immediately end the interaction.
-	if action.Err != nil {
-		mock.Done(action.Err)
-		return
-	}
-
-	mock.mutex.Lock()
-	mock.interactionComplete = mock.interactionComplete || action.InteractionComplete
-
-	mock.disconnectExpected = mock.disconnectExpected || action.DisconnectExpected
-	mock.mutex.Unlock()
-
-	if action.Messages != nil {
-		mock.reply <- action.Messages
-	}
-}
-
-// ConnectionClosed is called when the real peer closes the connection to the mock peer.
-func (mock *MockConnection) ConnectionClosed() {
-	mock.mutex.RLock()
-	ic := mock.interactionComplete
-	mock.mutex.RUnlock()
-	if !ic &&
-		(!mock.disconnectExpected ||
-			(mock.msgQueue != nil && mock.queuePlace < len(mock.msgQueue))) {
-		mock.Done(errors.New("Connection closed prematurely."))
-	}
-	mock.Done(nil)
-}
-
-// Done stops the server and ends the test.
-func (mock *MockConnection) Done(err error) {
-	if atomic.AddInt32(&mock.reported, 1) > 1 {
-		// The report has already been submitted.
-		return
-	}
-	mock.mutex.Lock()
-	mock.timer.Stop()
-	mock.interactionComplete = true
-	mock.mutex.Unlock()
-	mock.report <- TestReport{err, mock.objectData}
-}
-
-// Start loads the mock peer's initial action if there is one.
-func (mock *MockConnection) BeginTest() {
-	action := mock.peerTest.OnStart()
-
-	if action == nil {
-		return
-	}
-
-	mock.mutex.Lock()
-	mock.interactionComplete = mock.interactionComplete || action.InteractionComplete
-
-	mock.disconnectExpected = mock.disconnectExpected || action.DisconnectExpected
-	mock.mutex.Unlock()
-
-	if action.Messages == nil {
-		return
-	}
-
-	if mock.msgQueue == nil {
-		mock.msgQueue = action.Messages
-		mock.queuePlace = 0
-	}
-}
-
-func NewMockConnection(localAddr, remoteAddr net.Addr, report chan TestReport, peerTest PeerTest) *MockConnection {
-	mock := &MockConnection{
-		localAddr:           localAddr,
-		remoteAddr:          remoteAddr,
-		report:              report,
-		peerTest:            peerTest,
-		interactionComplete: false,
-		disconnectExpected:  false,
-		reply:               make(chan []wire.Message),
-		objectData:          make([]*wire.ShaHash, 0),
-	}
-
-	mock.mutex.Lock()
-	mock.timer = time.AfterFunc(time.Millisecond*100, func() {
-		mock.mutex.RLock()
-		ic := mock.interactionComplete
-		mock.mutex.RUnlock()
-		if !ic {
-			if mock.disconnectExpected {
-				mock.Done(errors.New("Peer stopped interacting when it was expected to disconnect."))
-			} else {
-				mock.Done(errors.New("Peer stopped interacting (without disconnecting) before the interaction was complete."))
-			}
-		} else {
-			mock.Done(nil)
-		}
-	})
-	mock.mutex.Unlock()
-
-	mock.BeginTest()
-
-	return mock
-}
-
-// MockListener implements the Listener interface
-type MockListener struct {
-	incoming     chan peer.Connection
-	disconnect   chan struct{}
-	localAddr    net.Addr
-	disconnected bool
-}
-
-func (ml *MockListener) Accept() (peer.Connection, error) {
-	if ml.disconnected {
-		return nil, errors.New("Listner disconnected.")
-	}
-	select {
-	case <-ml.disconnect:
-		return nil, errors.New("Listener disconnected.")
-	case m := <-ml.incoming:
-		return m, nil
-	}
-}
-
-func (ml *MockListener) Close() error {
-	ml.disconnect <- struct{}{}
-	return nil
-}
-
-// Addr returns the listener's network address.
-func (ml *MockListener) Addr() net.Addr {
-	return ml.localAddr
-}
-
-func NewMockListener(localAddr net.Addr, incoming chan peer.Connection, disconnect chan struct{}) *MockListener {
-	return &MockListener{
-		incoming:   incoming,
-		disconnect: disconnect,
-		localAddr:  localAddr,
-	}
-}
-
-// MockListen returns a mock listener
-func MockListen(listeners []*MockListener) func(string, string) (peer.Listener, error) {
-	i := 0
-
-	return func(service, addr string) (peer.Listener, error) {
-		i++
-		if i > len(listeners) {
-			return nil, errors.New("No mock listeners remaining.")
-		}
-
-		return listeners[i-1], nil
-	}
 }
 
 func getMemDb(msgs []*wire.MsgObject) database.Db {
@@ -994,7 +249,7 @@ func TestOutboundPeerHandshake(t *testing.T) {
 	// A peer that establishes a handshake for outgoing peers.
 	handshakePeerBuilder := func(action *PeerAction) func(net.Addr, int64, int64) peer.Connection {
 		return func(addr net.Addr, maxDown, maxUp int64) peer.Connection {
-			return NewMockConnection(localAddr, remoteAddr, report,
+			return NewMockPeer(localAddr, remoteAddr, report,
 				NewOutboundHandshakePeerTester(action, msgAddr))
 		}
 	}
@@ -1112,7 +367,7 @@ func TestInboundPeerHandshake(t *testing.T) {
 		serv.Start()
 
 		// Test handshake.
-		incoming <- NewMockConnection(localAddr, remoteAddr, report,
+		incoming <- NewMockPeer(localAddr, remoteAddr, report,
 			NewInboundHandshakePeerTester(open, addrAction))
 
 		msg := <-report
@@ -1178,22 +433,27 @@ func TestProcessAddr(t *testing.T) {
 		NumAddrs   int         // Number of addresses to put in the address manager.
 	}{
 		{
-			&PeerAction{[]wire.Message{addrMsg}, nil, false, false},
+			&PeerAction{
+				Messages: []wire.Message{addrMsg},
+			},
 			25,
 		},
 		{
-			&PeerAction{[]wire.Message{addrMsgTooLong}, nil, true, true},
+			&PeerAction{
+				Messages:            []wire.Message{addrMsgTooLong},
+				InteractionComplete: true,
+				DisconnectExpected:  true,
+			},
 			25,
 		},
 		{
-			&PeerAction{nil, nil, true, false},
+			&PeerAction{InteractionComplete: true},
 			0,
 		},
 	}
 
 	for testCase, addrTest := range AddrTests {
 		defer resetCfg(cfg)()
-
 		// Add some addresses to the address manager.
 		addrs := make([]*wire.NetAddress, addrTest.NumAddrs)
 
@@ -1214,7 +474,7 @@ func TestProcessAddr(t *testing.T) {
 
 		serv.addrManager.AddAddresses(addrs, srcAddr)
 
-		mockConn := NewMockConnection(localAddr, remoteAddr, report,
+		mockConn := NewMockPeer(localAddr, remoteAddr, report,
 			NewInboundHandshakePeerTester(
 				&PeerAction{Messages: []wire.Message{wire.NewMsgVersion(addrin, addrout, nonce, streams)}},
 				addrTest.AddrAction))
@@ -1228,65 +488,6 @@ func TestProcessAddr(t *testing.T) {
 		serv.Stop()
 
 		serv.WaitForShutdown()
-	}
-}
-
-type MockSendQueue struct {
-	conn         *MockConnection
-	msgQueue     chan wire.Message
-	requestQueue chan []*wire.InvVect
-	quit         chan struct{}
-}
-
-func (msq *MockSendQueue) QueueMessage(msg wire.Message) error {
-	msq.msgQueue <- msg
-	return nil
-}
-
-func (msq *MockSendQueue) QueueDataRequest(inv []*wire.InvVect) error {
-	msq.requestQueue <- inv
-	return nil
-}
-
-func (msq *MockSendQueue) QueueInventory([]*wire.InvVect) error {
-	return nil
-}
-
-// Start ignores its input here because we need a MockConnection, which has some
-// extra functions that the regular Connection does not have.
-func (msq *MockSendQueue) Start(conn peer.Connection) {
-	go msq.handler()
-}
-
-func (msq *MockSendQueue) Running() bool {
-	return true
-}
-
-func (msq *MockSendQueue) Stop() {
-	close(msq.quit)
-}
-
-// Must be run as a go routine.
-func (msq *MockSendQueue) handler() {
-out:
-	for {
-		select {
-		case <-msq.quit:
-			break out
-		case inv := <-msq.requestQueue:
-			msq.conn.RequestData(inv)
-		case msg := <-msq.msgQueue:
-			msq.conn.WriteMessage(msg)
-		}
-	}
-}
-
-func NewMockSendQueue(mockConn *MockConnection) *MockSendQueue {
-	return &MockSendQueue{
-		conn:         mockConn,
-		msgQueue:     make(chan wire.Message, 1),
-		requestQueue: make(chan []*wire.InvVect, 1),
-		quit:         make(chan struct{}),
 	}
 }
 
@@ -1378,7 +579,6 @@ func TestProcessInvAndObjectExchange(t *testing.T) {
 
 	for testCase, test := range tests {
 		defer resetCfg(cfg)()
-
 		// Define the objects that will go in the database.
 		// Create server and start it.
 		listeners := []string{net.JoinHostPort("", "8445")}
@@ -1392,9 +592,9 @@ func TestProcessInvAndObjectExchange(t *testing.T) {
 
 		serv.Start()
 
-		mockConn := NewMockConnection(localAddr, remoteAddr, report,
+		mockConn := NewMockPeer(localAddr, remoteAddr, report,
 			NewDataExchangePeerTester(test.mockDB, test.peerDB, test.invAction))
-		mockSend := NewMockSendQueue(mockConn)
+		mockSend := NewMockSend(mockConn)
 		inventory := peer.NewInventory()
 		na, _ := wire.NewNetAddress(remoteAddr, 1, 0)
 		serv.handleAddPeerMsg(tstNewPeerHandshakeComplete(serv, mockConn, inventory, mockSend, na))

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -301,6 +301,12 @@ func TestRPCConnection(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// If two connections take place at a close enough time together, it can
+	// happen that the second connection is accepted before the connection count
+	// has been updated after the previous connection. Thus, we wait a tiny amount
+	// to make sure the count is updated. This could probably be fixed eventually.
+	time.Sleep(20 * time.Millisecond)
+
 	_, _, err = websocket.DefaultDialer.Dial(rpcLoc, nil)
 	if err == nil {
 		t.Error("RPCMaxClients isn't enforced. Second connection was successful.")

--- a/server.go
+++ b/server.go
@@ -103,7 +103,7 @@ func newPeerState(maxOutbound int) *peerState {
 }
 
 // server provides a bitmssage server for handling communications to and from
-// bitcoin peers.
+// bitmessage peers.
 type server struct {
 	nonce         uint64
 	listeners     []peer.Listener

--- a/testobjects_test.go
+++ b/testobjects_test.go
@@ -1,0 +1,826 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/monetas/bmd/peer"
+	"github.com/monetas/bmutil/wire"
+)
+
+// randomShaHash returns a ShaHash with a random string of bytes in it.
+func randomShaHash() *wire.ShaHash {
+	b := make([]byte, 32)
+	for i := 0; i < 32; i++ {
+		b[i] = byte(rand.Intn(256))
+	}
+	hash, _ := wire.NewShaHash(b)
+	return hash
+}
+
+// toObject is used to return an object message type when it is certain that the
+// input message is encodable as such.
+func toMsgObject(msg wire.Message) *wire.MsgObject {
+	obj, _ := wire.ToMsgObject(msg)
+	return obj
+}
+
+func toObjectType(obj *wire.MsgObject) wire.Message {
+	var buf bytes.Buffer
+	wire.WriteMessage(&buf, obj, 0)
+
+	msg, _, _ := wire.ReadMessage(&buf, 0)
+	return msg
+}
+
+// MockListener implements the peer.Listener interface
+type MockListener struct {
+	incoming     chan peer.Connection
+	disconnect   chan struct{}
+	localAddr    net.Addr
+	disconnected bool
+}
+
+func (ml *MockListener) Accept() (peer.Connection, error) {
+	if ml.disconnected {
+		return nil, errors.New("Listner disconnected.")
+	}
+	select {
+	case <-ml.disconnect:
+		return nil, errors.New("Listener disconnected.")
+	case m := <-ml.incoming:
+		return m, nil
+	}
+}
+
+func (ml *MockListener) Close() error {
+	ml.disconnect <- struct{}{}
+	return nil
+}
+
+// Addr returns the listener's network address.
+func (ml *MockListener) Addr() net.Addr {
+	return ml.localAddr
+}
+
+func NewMockListener(localAddr net.Addr, incoming chan peer.Connection, disconnect chan struct{}) *MockListener {
+	return &MockListener{
+		incoming:   incoming,
+		disconnect: disconnect,
+		localAddr:  localAddr,
+	}
+}
+
+// MockListen returns a mock listener
+func MockListen(listeners []*MockListener) func(string, string) (peer.Listener, error) {
+	i := 0
+
+	return func(service, addr string) (peer.Listener, error) {
+		i++
+		if i > len(listeners) {
+			return nil, errors.New("No mock listeners remaining.")
+		}
+
+		return listeners[i-1], nil
+	}
+}
+
+// The report that the MockConnection sends when its interaction is complete.
+// If the error is nil, then the test has completed successfully.
+// The report also includes any object messages that were sent to the peer.
+type TestReport struct {
+	Err      error
+	DataSent []*wire.ShaHash
+}
+
+// MockPeer implements the peer.Connection interface and
+// is a mock peer to be used for testing purposes.
+type MockPeer struct {
+	// After a message is processed, the replies are sent here.
+	reply chan []wire.Message
+
+	// A channel used to report invalid states to the test.
+	report chan TestReport
+
+	// A function that manages the sequence of steps that the test should go through.
+	// This is the part that is customized for each test.
+	//handle     func(wire.Message) *PeerAction
+	peerTest PeerTest
+
+	// A list of hashes of objects that have been sent to the real peer.
+	objectData []*wire.ShaHash
+
+	// A queue of messages to be received by the real peer.
+	msgQueue []wire.Message
+
+	// The current place in the queue.
+	queuePlace int
+
+	// The test ends when the timer runs out. Until the interaction is complete,
+	// the timer is reset with every message received. Some time is required after
+	// the mock peer is done interacting with the real one to see if the real peer
+	// disconnects or not.
+	timer *time.Timer
+
+	// when interactionComplete is set, the mock peer no longer processes incoming
+	// messages or resets the timer. It is just waiting to see whether the real peer
+	// disconnects.
+	interactionComplete bool
+
+	// Whether the peer is expected to disconnect.
+	disconnectExpected bool
+
+	localAddr  net.Addr
+	remoteAddr net.Addr
+
+	// Whether the report has already been submitted.
+	reported int32
+
+	// A mutex for data that might be accessed by different threads.
+	mutex sync.RWMutex
+}
+
+func (mock *MockPeer) ReadMessage() (wire.Message, error) {
+	// If the queue is empty, get a new message from the channel.
+	for mock.msgQueue == nil || mock.queuePlace >= len(mock.msgQueue) {
+		mock.msgQueue = <-mock.reply
+		mock.queuePlace = 0
+	}
+
+	toSend := mock.msgQueue[mock.queuePlace]
+
+	mock.queuePlace++
+
+	if mock.queuePlace >= len(mock.msgQueue) {
+		mock.msgQueue = nil
+	}
+
+	switch t := toSend.(type) {
+	case *wire.MsgGetPubKey, *wire.MsgPubKey, *wire.MsgMsg, *wire.MsgBroadcast, *wire.MsgUnknownObject, *wire.MsgObject:
+		msg, _ := wire.ToMsgObject(t)
+		mock.mutex.Lock()
+		mock.objectData = append(mock.objectData, msg.InventoryHash())
+		mock.mutex.Unlock()
+	}
+
+	return toSend, nil
+}
+
+// WriteMessage figures out how to respond to a message once it is decyphered.
+func (mock *MockPeer) WriteMessage(rmsg wire.Message) error {
+	// We can keep receiving messages after the interaction is done; we just
+	// ignore them.	 We are waiting to see whether the peer disconnects.
+	mock.mutex.RLock()
+	ic := mock.interactionComplete
+	mock.mutex.RUnlock()
+	if ic {
+		return nil
+	}
+
+	mock.mutex.Lock()
+	mock.timer.Reset(time.Second)
+	mock.mutex.Unlock()
+	mock.handleAction(mock.handleMessage(rmsg))
+	return nil
+}
+
+func (mock *MockPeer) RequestData(invVect []*wire.InvVect) error {
+	// We can keep receiving messages after the interaction is done; we just ignore them.
+	// We are waiting to see whether the peer disconnects.
+	mock.mutex.RLock()
+	ic := mock.interactionComplete
+	mock.mutex.RUnlock()
+	if ic {
+		return nil
+	}
+
+	mock.mutex.Lock()
+	mock.timer.Reset(time.Second)
+	mock.mutex.Unlock()
+	mock.handleAction(mock.peerTest.OnSendData(invVect))
+	return nil
+}
+
+func (mock *MockPeer) BytesWritten() uint64 {
+	return 0
+}
+
+func (mock *MockPeer) BytesRead() uint64 {
+	return 0
+}
+
+func (mock *MockPeer) LastWrite() time.Time {
+	return time.Time{}
+}
+
+func (mock *MockPeer) LastRead() time.Time {
+	return time.Time{}
+}
+
+// LocalAddr returns the localAddr field of the fake connection and satisfies
+// the net.Conn interface.
+func (mock *MockPeer) LocalAddr() net.Addr {
+	return mock.localAddr
+}
+
+// RemoteAddr returns the remoteAddr field of the fake connection and satisfies
+// the net.Conn interface.
+func (mock *MockPeer) RemoteAddr() net.Addr {
+	return mock.remoteAddr
+}
+
+func (mock *MockPeer) Close() {
+	mock.ConnectionClosed()
+}
+
+func (mock *MockPeer) Connected() bool {
+	return true
+}
+
+func (mock *MockPeer) Connect() error {
+	return errors.New("Already connected.")
+}
+
+func (mock *MockPeer) handleMessage(msg wire.Message) *PeerAction {
+	switch msg.(type) {
+	case *wire.MsgVersion:
+		return mock.peerTest.OnMsgVersion(msg.(*wire.MsgVersion))
+	case *wire.MsgVerAck:
+		return mock.peerTest.OnMsgVerAck(msg.(*wire.MsgVerAck))
+	case *wire.MsgAddr:
+		return mock.peerTest.OnMsgAddr(msg.(*wire.MsgAddr))
+	case *wire.MsgInv:
+		return mock.peerTest.OnMsgInv(msg.(*wire.MsgInv))
+	case *wire.MsgGetData:
+		return mock.peerTest.OnMsgGetData(msg.(*wire.MsgGetData))
+	default:
+		return nil
+	}
+}
+
+func (mock *MockPeer) handleAction(action *PeerAction) {
+	// A nil response means to do nothing.
+	if action == nil {
+		return
+	}
+
+	// If an error is returned, immediately end the interaction.
+	if action.Err != nil {
+		mock.Done(action.Err)
+		return
+	}
+
+	mock.mutex.Lock()
+	mock.interactionComplete = mock.interactionComplete || action.InteractionComplete
+
+	mock.disconnectExpected = mock.disconnectExpected || action.DisconnectExpected
+	mock.mutex.Unlock()
+
+	if action.Messages != nil {
+
+		mock.reply <- action.Messages
+	}
+}
+
+// ConnectionClosed is called when the real peer closes the connection to the mock peer.
+func (mock *MockPeer) ConnectionClosed() {
+	mock.mutex.RLock()
+	ic := mock.interactionComplete
+	mock.mutex.RUnlock()
+	if !ic &&
+		(!mock.disconnectExpected ||
+			(mock.msgQueue != nil && mock.queuePlace < len(mock.msgQueue))) {
+		mock.Done(errors.New("Connection closed prematurely."))
+	}
+	mock.Done(nil)
+}
+
+// Done stops the server and ends the test.
+func (mock *MockPeer) Done(err error) {
+	if atomic.AddInt32(&mock.reported, 1) > 1 {
+		// The report has already been submitted.
+		return
+	}
+	mock.mutex.Lock()
+	mock.timer.Stop()
+	mock.interactionComplete = true
+	mock.report <- TestReport{err, mock.objectData}
+	mock.mutex.Unlock()
+}
+
+// Start loads the mock peer's initial action if there is one.
+func (mock *MockPeer) BeginTest() {
+	action := mock.peerTest.OnStart()
+
+	if action == nil {
+		return
+	}
+
+	mock.mutex.Lock()
+	mock.interactionComplete = mock.interactionComplete || action.InteractionComplete
+
+	mock.disconnectExpected = mock.disconnectExpected || action.DisconnectExpected
+	mock.mutex.Unlock()
+
+	if action.Messages == nil {
+		return
+	}
+
+	if mock.msgQueue == nil {
+		mock.msgQueue = action.Messages
+		mock.queuePlace = 0
+	}
+}
+
+func NewMockPeer(localAddr, remoteAddr net.Addr, report chan TestReport, peerTest PeerTest) *MockPeer {
+	mock := &MockPeer{
+		localAddr:           localAddr,
+		remoteAddr:          remoteAddr,
+		report:              report,
+		peerTest:            peerTest,
+		interactionComplete: false,
+		disconnectExpected:  false,
+		reply:               make(chan []wire.Message),
+		objectData:          make([]*wire.ShaHash, 0),
+	}
+
+	mock.mutex.Lock()
+	mock.timer = time.AfterFunc(time.Millisecond*100, func() {
+		mock.mutex.RLock()
+		ic := mock.interactionComplete
+		mock.mutex.RUnlock()
+		if !ic {
+			if mock.disconnectExpected {
+				mock.Done(errors.New("Peer stopped interacting when it was expected to disconnect."))
+			} else {
+				mock.Done(errors.New("Peer stopped interacting (without disconnecting) before the interaction was complete."))
+			}
+		} else {
+			mock.Done(nil)
+		}
+	})
+	mock.mutex.Unlock()
+
+	mock.BeginTest()
+
+	return mock
+}
+
+type MockSend struct {
+	conn         *MockPeer
+	msgQueue     chan wire.Message
+	requestQueue chan []*wire.InvVect
+	quit         chan struct{}
+}
+
+func (msq *MockSend) QueueMessage(msg wire.Message) error {
+	msq.msgQueue <- msg
+	return nil
+}
+
+func (msq *MockSend) QueueDataRequest(inv []*wire.InvVect) error {
+	msq.requestQueue <- inv
+	return nil
+}
+
+func (msq *MockSend) QueueInventory([]*wire.InvVect) error {
+	return nil
+}
+
+// Start ignores its input here because we need a MockConnection, which has some
+// extra functions that the regular Connection does not have.
+func (msq *MockSend) Start(conn peer.Connection) {
+	go msq.handler()
+}
+
+func (msq *MockSend) Running() bool {
+	return true
+}
+
+func (msq *MockSend) Stop() {
+	close(msq.quit)
+}
+
+// Must be run as a go routine.
+func (msq *MockSend) handler() {
+out:
+	for {
+		select {
+		case <-msq.quit:
+			break out
+		case inv := <-msq.requestQueue:
+			msq.conn.RequestData(inv)
+		case msg := <-msq.msgQueue:
+			msq.conn.WriteMessage(msg)
+		}
+	}
+}
+
+func NewMockSend(mockConn *MockPeer) *MockSend {
+	return &MockSend{
+		conn:         mockConn,
+		msgQueue:     make(chan wire.Message, 1),
+		requestQueue: make(chan []*wire.InvVect, 1),
+		quit:         make(chan struct{}),
+	}
+}
+
+// PeerAction represents a an action to be taken by the mock peer and information
+// about the expected response from the real peer.
+type PeerAction struct {
+	// A series of messages to send to the real peer.
+	Messages []wire.Message
+
+	// If an error is set, the interaction ends immediately.
+	Err error
+
+	// Whether the interaction is complete.
+	InteractionComplete bool
+
+	// For negative tests, we expect the peer to disconnect after the interaction is
+	// complete. If disconnectExpected is set, the test fails if the real peer fails
+	// to disconnect after half a second.
+	DisconnectExpected bool
+}
+
+// PeerTest is a type that defines the high-level behavior of a peer.
+type PeerTest interface {
+	OnStart() *PeerAction
+	OnMsgVersion(p *wire.MsgVersion) *PeerAction
+	OnMsgVerAck(p *wire.MsgVerAck) *PeerAction
+	OnMsgAddr(p *wire.MsgAddr) *PeerAction
+	OnMsgInv(p *wire.MsgInv) *PeerAction
+	OnMsgGetData(p *wire.MsgGetData) *PeerAction
+	OnSendData(invVect []*wire.InvVect) *PeerAction
+}
+
+// OutboundHandshakePeerTester is an implementation of PeerTest that is for
+// testing the handshake with an outbound peer.
+type OutboundHandshakePeerTester struct {
+	versionReceived   bool
+	handshakeComplete bool
+	response          *PeerAction
+	msgAddr           wire.Message
+	mutex             sync.RWMutex
+}
+
+func (peer *OutboundHandshakePeerTester) OnStart() *PeerAction {
+	return nil
+}
+
+func (peer *OutboundHandshakePeerTester) VersionReceived() bool {
+	peer.mutex.RLock()
+	defer peer.mutex.RUnlock()
+
+	return peer.versionReceived
+}
+
+func (peer *OutboundHandshakePeerTester) HandshakeComplete() bool {
+	peer.mutex.RLock()
+	defer peer.mutex.RUnlock()
+
+	return peer.handshakeComplete
+}
+
+func (peer *OutboundHandshakePeerTester) OnMsgVersion(version *wire.MsgVersion) *PeerAction {
+	if peer.VersionReceived() {
+		return &PeerAction{Err: errors.New("Two version messages received")}
+	}
+	peer.versionReceived = true
+	return peer.response
+}
+
+func (peer *OutboundHandshakePeerTester) OnMsgVerAck(p *wire.MsgVerAck) *PeerAction {
+	if !peer.VersionReceived() {
+		return &PeerAction{Err: errors.New("Expecting version message first.")}
+	}
+	peer.mutex.Lock()
+	peer.handshakeComplete = true
+	peer.mutex.Unlock()
+	return &PeerAction{
+		Messages:            []wire.Message{peer.msgAddr},
+		InteractionComplete: true,
+		DisconnectExpected:  false,
+	}
+}
+
+func (peer *OutboundHandshakePeerTester) OnMsgAddr(p *wire.MsgAddr) *PeerAction {
+	if peer.HandshakeComplete() {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
+}
+
+func (peer *OutboundHandshakePeerTester) OnMsgInv(p *wire.MsgInv) *PeerAction {
+	if peer.HandshakeComplete() {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
+}
+
+func (peer *OutboundHandshakePeerTester) OnMsgGetData(p *wire.MsgGetData) *PeerAction {
+	if peer.HandshakeComplete() {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
+}
+
+func (peer *OutboundHandshakePeerTester) OnSendData(invVect []*wire.InvVect) *PeerAction {
+	if peer.HandshakeComplete() {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Object message not allowed before handshake is complete.")}
+}
+
+func NewOutboundHandshakePeerTester(action *PeerAction, msgAddr wire.Message) *OutboundHandshakePeerTester {
+	return &OutboundHandshakePeerTester{
+		versionReceived:   false,
+		handshakeComplete: false,
+		response:          action,
+		msgAddr:           msgAddr,
+	}
+}
+
+// InboundHandsakePeerTester implements the PeerTest interface and is used to test
+// handshakes with inbound peers and the exchange of the addr messages.
+type InboundHandshakePeerTester struct {
+	verackReceived    bool
+	versionReceived   bool
+	handshakeComplete bool
+	openMsg           *PeerAction
+	addrAction        *PeerAction
+}
+
+func (peer *InboundHandshakePeerTester) OnStart() *PeerAction {
+	return peer.openMsg
+}
+
+func (peer *InboundHandshakePeerTester) OnMsgVersion(version *wire.MsgVersion) *PeerAction {
+	if peer.versionReceived {
+		return &PeerAction{Err: errors.New("Two versions received?")}
+	}
+	peer.versionReceived = true
+	if peer.verackReceived {
+		// Handshake completed successfully
+		peer.handshakeComplete = true
+
+		// Sending an addr message to make sure the peer doesn't disconnect.
+		return peer.addrAction
+	}
+	return &PeerAction{[]wire.Message{&wire.MsgVerAck{}}, nil, false, false}
+}
+
+func (peer *InboundHandshakePeerTester) OnMsgVerAck(p *wire.MsgVerAck) *PeerAction {
+	if peer.verackReceived {
+		return &PeerAction{Err: errors.New("Two veracks received?")}
+	}
+	peer.verackReceived = true
+	if peer.versionReceived {
+		// Handshake completed successfully
+		peer.handshakeComplete = true
+
+		//Sending an addr message to make sure the peer doesn't disconnect.
+		return peer.addrAction
+	}
+	// Return nothing and await a version message.
+	return &PeerAction{nil, nil, false, false}
+}
+
+func (peer *InboundHandshakePeerTester) OnMsgAddr(p *wire.MsgAddr) *PeerAction {
+	if peer.handshakeComplete {
+		return &PeerAction{nil, nil, true, false}
+	}
+	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
+}
+
+func (peer *InboundHandshakePeerTester) OnMsgInv(p *wire.MsgInv) *PeerAction {
+	if peer.handshakeComplete {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
+}
+
+func (peer *InboundHandshakePeerTester) OnMsgGetData(p *wire.MsgGetData) *PeerAction {
+	if peer.handshakeComplete {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Not allowed before handshake is complete.")}
+}
+
+func (peer *InboundHandshakePeerTester) OnSendData(invVect []*wire.InvVect) *PeerAction {
+	if peer.handshakeComplete {
+		return nil
+	}
+	return &PeerAction{Err: errors.New("Object message not allowed before handshake is complete.")}
+}
+
+func NewInboundHandshakePeerTester(openingMsg *PeerAction, addrAction *PeerAction) *InboundHandshakePeerTester {
+	return &InboundHandshakePeerTester{
+		verackReceived:    false,
+		versionReceived:   false,
+		handshakeComplete: false,
+		openMsg:           openingMsg,
+		addrAction:        addrAction,
+	}
+}
+
+// DataExchangePeerTester implements the PeerTest interface and tests the exchange
+// of inv messages and data.
+type DataExchangePeerTester struct {
+	dataSent      bool
+	dataReceived  bool
+	invReceived   bool
+	invAction     *PeerAction
+	inventory     map[wire.InvVect]*wire.MsgObject // The initial inventory of the mock peer.
+	peerInventory map[wire.InvVect]struct{}        // The initial inventory of the real peer.
+	requested     map[wire.InvVect]struct{}        // The messages that were requested.
+}
+
+func (peer *DataExchangePeerTester) OnStart() *PeerAction {
+	return peer.invAction
+}
+
+func (peer *DataExchangePeerTester) OnMsgVersion(version *wire.MsgVersion) *PeerAction {
+	return &PeerAction{Err: errors.New("This test should begin with handshake already done.")}
+}
+
+func (peer *DataExchangePeerTester) OnMsgVerAck(p *wire.MsgVerAck) *PeerAction {
+	return &PeerAction{Err: errors.New("This test should begin with handshake already done.")}
+}
+
+func (peer *DataExchangePeerTester) OnMsgAddr(p *wire.MsgAddr) *PeerAction {
+	return nil
+}
+
+func (peer *DataExchangePeerTester) OnMsgInv(inv *wire.MsgInv) *PeerAction {
+	if peer.invReceived {
+		return &PeerAction{Err: errors.New("Inv message allready received.")}
+	}
+
+	peer.invReceived = true
+
+	if len(inv.InvList) == 0 {
+		return &PeerAction{Err: errors.New("Empty inv message received.")}
+	}
+
+	if len(inv.InvList) > wire.MaxInvPerMsg {
+		return &PeerAction{Err: errors.New("Excessively long inv message received.")}
+	}
+
+	// Return a get data message that requests the entries in inv which are not already known.
+	i := 0
+	var ok bool
+	duplicate := make(map[wire.InvVect]struct{})
+	newInvList := make([]*wire.InvVect, len(inv.InvList))
+	for _, iv := range inv.InvList {
+		if _, ok = peer.inventory[*iv]; !ok {
+			if _, ok = duplicate[*iv]; ok {
+				return &PeerAction{Err: errors.New("Inv with duplicates received.")}
+			}
+			duplicate[*iv] = struct{}{}
+			newInvList[i] = iv
+			peer.requested[*iv] = struct{}{}
+			i++
+		}
+	}
+
+	if i == 0 {
+		return nil
+	}
+
+	return &PeerAction{
+		Messages: []wire.Message{&wire.MsgGetData{InvList: newInvList[:i]}},
+	}
+}
+
+func (peer *DataExchangePeerTester) OnMsgGetData(getData *wire.MsgGetData) *PeerAction {
+
+	if len(getData.InvList) == 0 {
+		return &PeerAction{Err: errors.New("Empty GetData message received.")}
+	}
+
+	if len(getData.InvList) > wire.MaxInvPerMsg {
+		return &PeerAction{Err: errors.New("Excessively long GetData message received.")}
+	}
+
+	// The getdata message should include no duplicates and should include nothing
+	// that the peer already knows, and nothing that the mock peer doesn't know.
+	i := 0
+	duplicate := make(map[wire.InvVect]struct{})
+	messages := make([]wire.Message, len(getData.InvList))
+	for _, iv := range getData.InvList {
+		msg, ok := peer.inventory[*iv]
+		if !ok {
+			return &PeerAction{Err: errors.New("GetData asked for something we don't know.")}
+		}
+
+		if _, ok = duplicate[*iv]; ok {
+			return &PeerAction{Err: errors.New("GetData with duplicates received.")}
+		}
+
+		duplicate[*iv] = struct{}{}
+		messages[i] = toObjectType(msg)
+		peer.peerInventory[*iv] = struct{}{}
+		i++
+	}
+
+	peer.dataSent = true
+
+	if peer.dataReceived {
+		return &PeerAction{messages[:i], nil, true, false}
+	}
+	return &PeerAction{messages[:i], nil, false, false}
+}
+
+func (peer *DataExchangePeerTester) OnSendData(invVect []*wire.InvVect) *PeerAction {
+	if !peer.invReceived {
+		return &PeerAction{Err: errors.New("Object message not allowed before exchange of invs.")}
+	}
+
+	// The objects must have been requested.
+	for _, iv := range invVect {
+		if _, ok := peer.requested[*iv]; !ok {
+			return &PeerAction{Err: errors.New("Object message not allowed before handshake is complete.")}
+		}
+		delete(peer.requested, *iv)
+	}
+
+	if len(peer.requested) == 0 {
+		peer.dataReceived = true
+	}
+
+	if peer.dataReceived && peer.dataSent {
+		return &PeerAction{nil, nil, true, false}
+	}
+	return &PeerAction{nil, nil, false, false}
+}
+
+func NewDataExchangePeerTester(inventory []*wire.MsgObject, peerInventory []*wire.MsgObject, invAction *PeerAction) *DataExchangePeerTester {
+	// Catalog the initial inventories of the mock peer and real peer.
+	in := make(map[wire.InvVect]*wire.MsgObject)
+	pin := make(map[wire.InvVect]struct{})
+	invMsg := wire.NewMsgInv()
+
+	// Construct the real peer's inventory.
+	for _, message := range inventory {
+		inv := wire.InvVect{Hash: *message.InventoryHash()}
+		invMsg.AddInvVect(&inv)
+		in[inv] = message
+	}
+
+	// Construct the mock peer's inventory.
+	for _, message := range peerInventory {
+		inv := wire.InvVect{Hash: *message.InventoryHash()}
+		pin[inv] = struct{}{}
+	}
+
+	dataSent := true
+	dataReceived := true
+
+	// Does the real peer have any inventory that the mock peer does not have?
+	for inv := range in {
+		if _, ok := pin[inv]; !ok {
+			dataSent = false
+			break
+		}
+	}
+
+	// Does the mock peer have any inventory that the real peer does not?
+	for inv := range pin {
+		if _, ok := in[inv]; !ok {
+			dataReceived = false
+			break
+		}
+	}
+
+	var inva *PeerAction
+	if invAction == nil {
+		if len(invMsg.InvList) == 0 {
+			inva = &PeerAction{
+				Messages:            []wire.Message{&wire.MsgVerAck{}},
+				InteractionComplete: dataSent && dataReceived,
+			}
+		} else {
+			inva = &PeerAction{
+				Messages:            []wire.Message{&wire.MsgVerAck{}, invMsg},
+				InteractionComplete: dataSent && dataReceived,
+			}
+		}
+	} else {
+		inva = invAction
+	}
+
+	return &DataExchangePeerTester{
+		dataSent:      dataSent,
+		dataReceived:  dataReceived,
+		inventory:     in,
+		peerInventory: pin,
+		invAction:     inva,
+		requested:     make(map[wire.InvVect]struct{}),
+	}
+}


### PR DESCRIPTION
* Fixed bug in objectmanager that caused lots of peers to be disconnected at once due to expired object requests. 
* Fixed bug in database that sometimes returned nil hashes in RemoveExpiredObjects.
* Moved the test objects to their own files. 
* Some work simplifying the tests slightly. 
* An earlier bug fix created a condition in peer tests which sometimes caused all goroutines to lock up. I fixed the tests. 
* Rarely the rpc server test would fail if two connections were both started at the same time before the connection was actually read by either. I fixed the test so that the test does not fail, but it is still possible for this rare error case to happen if two connections are made at near enough the same time. 