### PR TITLE
Fix bug that caused server to run out of peers.

### DIFF
--- a/objmgr/objectmanager.go
+++ b/objmgr/objectmanager.go
@@ -496,7 +496,6 @@ func (om *ObjectManager) objectHandler() {
 		// Relay to the other peers all the new invs collected
 		// during the past ten seconds.
 		case <-relayInvTick.C:
-			log.Trace("Relay inv ticker ticked.")
 			if om.relayInvList.Len() == 0 {
 				continue
 			}

--- a/peer.go
+++ b/peer.go
@@ -10,7 +10,6 @@ package main
 import (
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/monetas/bmd/peer"
 )
@@ -30,7 +29,7 @@ func NewInboundPeer(s *server, conn peer.Connection) *peer.Peer {
 // NewOutboundPeer returns a new outbound bitmessage peer for the provided server and
 // address and connects to it asynchronously. If the connection is successful
 // then the peer will also be started.
-func NewOutboundPeer(addr string, s *server, stream uint32, persistent bool, retries reconnectionAttempts) *peer.Peer {
+func NewOutboundPeer(addr string, s *server, stream uint32, persistent bool) *peer.Peer {
 	// Setup p.na with a temporary address that we are connecting to with
 	// faked up service flags. We will replace this with the real one after
 	// version negotiation is successful. The only failure case here would
@@ -60,18 +59,6 @@ func NewOutboundPeer(addr string, s *server, stream uint32, persistent bool, ret
 	sq := peer.NewSend(inventory, s.db)
 	p := peer.NewPeer(s, conn, inventory, sq, na, false, persistent)
 
-	go func() {
-		// Wait for some time if this is a retry, and wait longer if we have
-		// tried multiple times.
-		if retries > 0 {
-			scaledInterval := connectionRetryInterval.Nanoseconds() * int64(retries) / 2
-			scaledDuration := time.Duration(scaledInterval)
-			time.Sleep(scaledDuration)
-		}
-
-		p.Start()
-
-		s.addrManager.Attempt(na)
-	}()
+	peerLog.Trace("NewOutboundPeer ", addr, " created.")
 	return p
 }

--- a/peer_test.go
+++ b/peer_test.go
@@ -578,7 +578,7 @@ func TestProcessInvAndObjectExchange(t *testing.T) {
 		mockSend := NewMockSend(mockConn)
 		inventory := peer.NewInventory()
 		serv.handleAddPeerMsg(peer.NewPeerHandshakeComplete(
-			serv, mockConn, inventory, mockSend, addrout))
+			serv, mockConn, inventory, mockSend, addrout), 0)
 
 		var msg TestReport
 		msg = <-report

--- a/rpcmethods.go
+++ b/rpcmethods.go
@@ -20,6 +20,8 @@ import (
 // SendObject inserts the object into bmd's database and sends it out to the
 // Bitmessage network.
 func (s *rpcServer) SendObject(ctx context.Context, in *pb.Object) (*pb.SendObjectReply, error) {
+	rpcLog.Trace("SendObject: object received to be sent out into the network.")
+
 	if code := s.restrictAuth(ctx); code != codes.OK {
 		return nil, grpc.Errorf(code, "auth failure")
 	}
@@ -56,6 +58,8 @@ func (s *rpcServer) SendObject(ctx context.Context, in *pb.Object) (*pb.SendObje
 		time.Now()) {
 		return nil, grpc.Errorf(codes.InvalidArgument, "invalid proof of work")
 	}
+
+	rpcLog.Trace("SendObject: Object will be sent out into the network.")
 
 	// Relay object to object manager which will handle insertion and
 	// advertisement.


### PR DESCRIPTION
The server kept entering a state in which none of its peers were doing anything but they were not getting removed from the PeerState. Basically, what happens is that the peer is sometimes added to the peer state before it has even connected. This is done to make it so that the peers are counted when the server detects whether it needs more peers to connect to. However, if the initial connection attempt failed, there was no guarantee that the peer would be removed from PeerState. I have rewritten some things so that the peer is guaranteed to be removed if the initial connection attempt fails.