### PR TITLE
Fixed bug that rarely caused the program to crash.

### DIFF
--- a/peer/connection.go
+++ b/peer/connection.go
@@ -145,14 +145,12 @@ func (pc *connection) RemoteAddr() net.Addr {
 
 // Close disconnects the peer and stops running the connection.
 func (pc *connection) Close() {
-	if pc.Connected() {
-		pc.connMtx.Lock()
-		conn := pc.conn
+	pc.connMtx.Lock()
+	if pc.conn != nil {
+		pc.conn.Close()
 		pc.conn = nil
-		pc.connMtx.Unlock()
-		conn.Close()
 	}
-
+	pc.connMtx.Unlock()
 	pc.idleTimer.Stop()
 }
 


### PR DESCRIPTION
Very rarely, the Close function would fail because it attempted to close a nil net.Conn. This happens I think on rare occasions when two goroutines would call Close at the same time. The fix ensures that one lock is maintained for the entire Close function. 